### PR TITLE
feat: add request deduplication for EnvexProvider endpoint fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,12 @@ node_modules/
 # Claude Code
 CLAUDE.md
 
+# Coverage
+coverage/
+
+# Screenshots
+__screenshots__/
+
 # Logs
 logs
 *.log

--- a/packages/envex/.releaserc.json
+++ b/packages/envex/.releaserc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@daniel-rose/semantic-release-config"
+}

--- a/packages/envex/src/react/EnvexProvider/index.tsx
+++ b/packages/envex/src/react/EnvexProvider/index.tsx
@@ -6,6 +6,7 @@ import type { Env } from '../../types.ts'
 import { filterPublicEnv } from '../../utils'
 import { EnvexContext } from './contexts'
 import type { EnvexProviderPropsInterface } from './types.ts'
+import { fetchEnv } from './utils'
 
 const EnvexProvider = (props: EnvexProviderPropsInterface) => {
   const { initialEnv, prefix, endpoint, children } = props
@@ -15,11 +16,23 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
 
   useEffect(() => {
     if (endpoint) {
-      void fetch(endpoint)
-        .then(res => res.json())
-        .then((data: Env) => setEnv(data))
+      let isCancelled = false
 
-      return
+      void fetchEnv(endpoint)
+        .then((data: Env) => {
+          if (!isCancelled) {
+            setEnv(data)
+          }
+        })
+        .catch((error: unknown) => {
+          if (!isCancelled) {
+            console.error('[envex] Failed to fetch env from endpoint:', error)
+          }
+        })
+
+      return () => {
+        isCancelled = true
+      }
     }
 
     if (!window.ENV || typeof window.ENV !== 'object') {

--- a/packages/envex/src/react/EnvexProvider/utils/fetchEnv/index.ts
+++ b/packages/envex/src/react/EnvexProvider/utils/fetchEnv/index.ts
@@ -1,0 +1,21 @@
+import type { Env } from '../../../../types.ts'
+import fetchEnvCache from '../fetchEnvCache'
+
+const fetchEnv = (endpoint: string): Promise<Env> => {
+  if (fetchEnvCache.promise && fetchEnvCache.endpoint === endpoint) {
+    return fetchEnvCache.promise
+  }
+
+  fetchEnvCache.endpoint = endpoint
+  fetchEnvCache.promise = fetch(endpoint)
+    .then(res => res.json() as Promise<Env>)
+    .catch((error: unknown) => {
+      fetchEnvCache.promise = null
+      fetchEnvCache.endpoint = null
+      throw error
+    })
+
+  return fetchEnvCache.promise
+}
+
+export default fetchEnv

--- a/packages/envex/src/react/EnvexProvider/utils/fetchEnvCache/index.ts
+++ b/packages/envex/src/react/EnvexProvider/utils/fetchEnvCache/index.ts
@@ -1,0 +1,13 @@
+import type { Env } from '../../../../types.ts'
+
+interface FetchEnvCache {
+  promise: Promise<Env> | null
+  endpoint: string | null
+}
+
+const fetchEnvCache: FetchEnvCache = {
+  promise: null,
+  endpoint: null,
+}
+
+export default fetchEnvCache

--- a/packages/envex/src/react/EnvexProvider/utils/index.ts
+++ b/packages/envex/src/react/EnvexProvider/utils/index.ts
@@ -1,0 +1,1 @@
+export { default as fetchEnv } from './fetchEnv'

--- a/packages/envex/src/react/EnvexProvider/utils/resetFetchEnvCache/index.ts
+++ b/packages/envex/src/react/EnvexProvider/utils/resetFetchEnvCache/index.ts
@@ -1,0 +1,8 @@
+import fetchEnvCache from '../fetchEnvCache'
+
+const resetFetchEnvCache = (): void => {
+  fetchEnvCache.promise = null
+  fetchEnvCache.endpoint = null
+}
+
+export default resetFetchEnvCache

--- a/packages/envex/tests/react/EnvexProvider/index.spec.tsx
+++ b/packages/envex/tests/react/EnvexProvider/index.spec.tsx
@@ -1,10 +1,16 @@
-import { expect, test, vi } from 'vitest'
+import { afterEach, expect, test, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 import {
   EnvexProvider,
   EnvexScriptIsMissingError,
   EnvexWindowEnvIsMissingError,
 } from '../../../src'
+import resetFetchEnvCache from '../../../src/react/EnvexProvider/utils/resetFetchEnvCache'
+
+afterEach(() => {
+  resetFetchEnvCache()
+  vi.restoreAllMocks()
+})
 
 test('Try to render "EnvProvider" without required window variable "ENV".', async () => {
   try {
@@ -53,8 +59,6 @@ test('Try to render "EnvProvider" with endpoint prop.', async () => {
   )
 
   await expect.element(getByText('Children')).toBeInTheDocument()
-
-  vi.restoreAllMocks()
 })
 
 test('Try to render "EnvProvider" with endpoint ignores window.ENV.', async () => {
@@ -73,5 +77,22 @@ test('Try to render "EnvProvider" with endpoint ignores window.ENV.', async () =
   await expect.element(getByText('Children')).toBeInTheDocument()
 
   delete window.ENV
-  vi.restoreAllMocks()
+})
+
+test('Multiple providers with same endpoint fire only one fetch.', async () => {
+  const mockEnv = { API_URL: 'https://api.example.com' }
+  const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+    json: () => Promise.resolve(mockEnv),
+  } as Response)
+
+  const { getByText } = await render(
+    <>
+      <EnvexProvider endpoint='/api/env'>Provider A</EnvexProvider>
+      <EnvexProvider endpoint='/api/env'>Provider B</EnvexProvider>
+    </>
+  )
+
+  await expect.element(getByText('Provider A')).toBeInTheDocument()
+  await expect.element(getByText('Provider B')).toBeInTheDocument()
+  expect(fetchSpy).toHaveBeenCalledTimes(1)
 })

--- a/packages/envex/tests/react/EnvexProvider/utils/fetchEnv/index.spec.ts
+++ b/packages/envex/tests/react/EnvexProvider/utils/fetchEnv/index.spec.ts
@@ -1,0 +1,84 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import fetchEnv from '../../../../../src/react/EnvexProvider/utils/fetchEnv'
+import resetFetchEnvCache from '../../../../../src/react/EnvexProvider/utils/resetFetchEnvCache'
+
+afterEach(() => {
+  resetFetchEnvCache()
+  vi.restoreAllMocks()
+})
+
+test('Returns data on successful fetch.', async () => {
+  const mockEnv = { API_URL: 'https://api.example.com' }
+
+  vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+    json: () => Promise.resolve(mockEnv),
+  } as Response)
+
+  const result = await fetchEnv('/api/env')
+
+  expect(result).toEqual(mockEnv)
+})
+
+test('Deduplicates: second call with same endpoint does not fetch again.', async () => {
+  const mockEnv = { API_URL: 'https://api.example.com' }
+  const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+    json: () => Promise.resolve(mockEnv),
+  } as Response)
+
+  await fetchEnv('/api/env')
+  await fetchEnv('/api/env')
+
+  expect(fetchSpy).toHaveBeenCalledTimes(1)
+})
+
+test('Both calls receive the same data.', async () => {
+  const mockEnv = { API_URL: 'https://api.example.com' }
+
+  vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+    json: () => Promise.resolve(mockEnv),
+  } as Response)
+
+  const [result1, result2] = await Promise.all([
+    fetchEnv('/api/env'),
+    fetchEnv('/api/env'),
+  ])
+
+  expect(result1).toBe(result2)
+})
+
+test('Different endpoint invalidates cache and fetches again.', async () => {
+  const mockEnv1 = { API_URL: 'https://api1.example.com' }
+  const mockEnv2 = { API_URL: 'https://api2.example.com' }
+  const fetchSpy = vi
+    .spyOn(globalThis, 'fetch')
+    .mockResolvedValueOnce({
+      json: () => Promise.resolve(mockEnv1),
+    } as Response)
+    .mockResolvedValueOnce({
+      json: () => Promise.resolve(mockEnv2),
+    } as Response)
+
+  const result1 = await fetchEnv('/api/env-1')
+  const result2 = await fetchEnv('/api/env-2')
+
+  expect(fetchSpy).toHaveBeenCalledTimes(2)
+  expect(result1).toEqual(mockEnv1)
+  expect(result2).toEqual(mockEnv2)
+})
+
+test('Error invalidates cache so next call retries.', async () => {
+  const mockEnv = { API_URL: 'https://api.example.com' }
+  const fetchSpy = vi
+    .spyOn(globalThis, 'fetch')
+    .mockRejectedValueOnce(new Error('Network error'))
+    .mockResolvedValueOnce({
+      json: () => Promise.resolve(mockEnv),
+    } as Response)
+
+  await expect(fetchEnv('/api/env')).rejects.toThrow('Network error')
+
+  const result = await fetchEnv('/api/env')
+
+  expect(result).toEqual(mockEnv)
+  expect(fetchSpy).toHaveBeenCalledTimes(2)
+})

--- a/packages/envex/tests/react/EnvexProvider/utils/resetFetchEnvCache/index.spec.ts
+++ b/packages/envex/tests/react/EnvexProvider/utils/resetFetchEnvCache/index.spec.ts
@@ -1,0 +1,26 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import fetchEnv from '../../../../../src/react/EnvexProvider/utils/fetchEnv'
+import resetFetchEnvCache from '../../../../../src/react/EnvexProvider/utils/resetFetchEnvCache'
+
+afterEach(() => {
+  resetFetchEnvCache()
+  vi.restoreAllMocks()
+})
+
+test('resetFetchEnvCache clears the cache.', async () => {
+  const mockEnv = { API_URL: 'https://api.example.com' }
+  const fetchSpy = vi
+    .spyOn(globalThis, 'fetch')
+    .mockResolvedValueOnce({
+      json: () => Promise.resolve(mockEnv),
+    } as Response)
+    .mockResolvedValueOnce({
+      json: () => Promise.resolve(mockEnv),
+    } as Response)
+
+  await fetchEnv('/api/env')
+  resetFetchEnvCache()
+  await fetchEnv('/api/env')
+
+  expect(fetchSpy).toHaveBeenCalledTimes(2)
+})


### PR DESCRIPTION
Multiple EnvexProvider instances with the same endpoint prop now share a single fetch request via module-level promise caching. This prevents redundant network requests in islands architectures where several isolated React roots use EnvexProvider simultaneously.