### PR TITLE
feat(envex): add Standard Schema validation for environment variables

### DIFF
--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -19,7 +19,8 @@
     "@daniel-rose/envex": "workspace:^",
     "next": "^16.2.4",
     "react": "^19.2.5",
-    "react-dom": "^19.2.5"
+    "react-dom": "^19.2.5",
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -19,7 +19,8 @@
     "@daniel-rose/envex": "workspace:^",
     "next": "^16.2.10",
     "react": "^19.2.7",
-    "react-dom": "^19.2.7"
+    "react-dom": "^19.2.7",
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",

--- a/examples/nextjs/src/app/api/env-schema/route.ts
+++ b/examples/nextjs/src/app/api/env-schema/route.ts
@@ -1,0 +1,4 @@
+import { createEnvRouteHandler } from '@daniel-rose/envex/server'
+import { envSchema } from '../../env'
+
+export const GET = createEnvRouteHandler({ schema: envSchema })

--- a/examples/nextjs/src/app/env.ts
+++ b/examples/nextjs/src/app/env.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod'
+
+export const envSchema = z.object({
+  NEXT_PUBLIC_FOO: z.string(),
+})
+
+export type AppEnv = z.infer<typeof envSchema>

--- a/examples/nextjs/src/app/schema/page.tsx
+++ b/examples/nextjs/src/app/schema/page.tsx
@@ -1,0 +1,12 @@
+import { getPublicEnv } from '@daniel-rose/envex/server'
+import { envSchema } from '../env'
+
+export default async function SchemaPage() {
+  const env = await getPublicEnv({ schema: envSchema })
+
+  return (
+    <div data-testid='schema-env'>
+      <span>NEXT_PUBLIC_FOO: {env.NEXT_PUBLIC_FOO}</span>
+    </div>
+  )
+}

--- a/examples/nextjs/tests/api.browser.spec.ts
+++ b/examples/nextjs/tests/api.browser.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'playwright/test'
+import { expect, test } from '@playwright/test'
 
 test('GET /api/env returns only NEXT_PUBLIC_ variables', async ({
   request,

--- a/examples/nextjs/tests/credential-scan.browser.spec.ts
+++ b/examples/nextjs/tests/credential-scan.browser.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'playwright/test'
+import { expect, test } from '@playwright/test'
 
 // Credential scanning is opt-in. The example enables it end-to-end: the layout
 // uses <EnvScript scan /> (built-in engine) and the /api/env route uses the

--- a/examples/nextjs/tests/envex.browser.spec.ts
+++ b/examples/nextjs/tests/envex.browser.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'playwright/test'
+import { expect, test } from '@playwright/test'
 
 test('Try to get dynamic env variable with prefix "NEXT_PUBLIC_"', async ({
   page,

--- a/examples/nextjs/tests/inline-env-script.browser.spec.ts
+++ b/examples/nextjs/tests/inline-env-script.browser.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'playwright/test'
+import { expect, test } from '@playwright/test'
 
 test('InlineEnvScript injects NEXT_PUBLIC_ variables into window.ENV', async ({
   page,

--- a/examples/nextjs/tests/schema.browser.spec.ts
+++ b/examples/nextjs/tests/schema.browser.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'playwright/test'
+import { expect, test } from '@playwright/test'
 
 test('GET /api/env-schema returns schema-validated public env', async ({
   request,

--- a/examples/nextjs/tests/schema.browser.spec.ts
+++ b/examples/nextjs/tests/schema.browser.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'playwright/test'
+
+test('GET /api/env-schema returns schema-validated public env', async ({
+  request,
+}) => {
+  const response = await request.get('/api/env-schema')
+
+  expect(response.status()).toBe(200)
+
+  const json = await response.json()
+
+  expect(json).toHaveProperty('NEXT_PUBLIC_FOO', 'bar')
+  expect(json).not.toHaveProperty('BAR')
+})
+
+test('Schema page renders Zod-validated env var', async ({ page }) => {
+  await page.goto('/schema')
+
+  const schemaEnv = page.locator('[data-testid="schema-env"]')
+  await expect(schemaEnv).toContainText('NEXT_PUBLIC_FOO: bar')
+})

--- a/packages/envex/CHANGELOG.md
+++ b/packages/envex/CHANGELOG.md
@@ -1,8 +1,9 @@
 # @daniel-rose/envex [1.6.0](https://github.com/daniel-rose/monorepo/compare/@daniel-rose/envex@1.5.0...@daniel-rose/envex@1.6.0) (2026-03-24)
 
+
 ### Features
 
-- add request deduplication for EnvexProvider endpoint fetching ([#108](https://github.com/daniel-rose/monorepo/issues/108)) ([2fc1e1f](https://github.com/daniel-rose/monorepo/commit/2fc1e1f5d59324086a97119dcae1844edbaa8dd3))
+* add request deduplication for EnvexProvider endpoint fetching ([#108](https://github.com/daniel-rose/monorepo/issues/108)) ([2fc1e1f](https://github.com/daniel-rose/monorepo/commit/2fc1e1f5d59324086a97119dcae1844edbaa8dd3))
 
 # @daniel-rose/envex [1.3.0](https://github.com/daniel-rose/envex/compare/@daniel-rose/envex@1.2.0...@daniel-rose/envex@1.3.0) (2025-12-13)
 

--- a/packages/envex/CHANGELOG.md
+++ b/packages/envex/CHANGELOG.md
@@ -1,9 +1,8 @@
 # @daniel-rose/envex [1.6.0](https://github.com/daniel-rose/monorepo/compare/@daniel-rose/envex@1.5.0...@daniel-rose/envex@1.6.0) (2026-03-24)
 
-
 ### Features
 
-* add request deduplication for EnvexProvider endpoint fetching ([#108](https://github.com/daniel-rose/monorepo/issues/108)) ([2fc1e1f](https://github.com/daniel-rose/monorepo/commit/2fc1e1f5d59324086a97119dcae1844edbaa8dd3))
+- add request deduplication for EnvexProvider endpoint fetching ([#108](https://github.com/daniel-rose/monorepo/issues/108)) ([2fc1e1f](https://github.com/daniel-rose/monorepo/commit/2fc1e1f5d59324086a97119dcae1844edbaa8dd3))
 
 # @daniel-rose/envex [1.3.0](https://github.com/daniel-rose/envex/compare/@daniel-rose/envex@1.2.0...@daniel-rose/envex@1.3.0) (2025-12-13)
 

--- a/packages/envex/CHANGELOG.md
+++ b/packages/envex/CHANGELOG.md
@@ -28,10 +28,9 @@
 
 # @daniel-rose/envex [1.6.0](https://github.com/daniel-rose/monorepo/compare/@daniel-rose/envex@1.5.0...@daniel-rose/envex@1.6.0) (2026-03-24)
 
-
 ### Features
 
-* add request deduplication for EnvexProvider endpoint fetching ([#108](https://github.com/daniel-rose/monorepo/issues/108)) ([2fc1e1f](https://github.com/daniel-rose/monorepo/commit/2fc1e1f5d59324086a97119dcae1844edbaa8dd3))
+- add request deduplication for EnvexProvider endpoint fetching ([#108](https://github.com/daniel-rose/monorepo/issues/108)) ([2fc1e1f](https://github.com/daniel-rose/monorepo/commit/2fc1e1f5d59324086a97119dcae1844edbaa8dd3))
 
 # @daniel-rose/envex [1.3.0](https://github.com/daniel-rose/envex/compare/@daniel-rose/envex@1.2.0...@daniel-rose/envex@1.3.0) (2025-12-13)
 

--- a/packages/envex/CHANGELOG.md
+++ b/packages/envex/CHANGELOG.md
@@ -28,9 +28,10 @@
 
 # @daniel-rose/envex [1.6.0](https://github.com/daniel-rose/monorepo/compare/@daniel-rose/envex@1.5.0...@daniel-rose/envex@1.6.0) (2026-03-24)
 
+
 ### Features
 
-- add request deduplication for EnvexProvider endpoint fetching ([#108](https://github.com/daniel-rose/monorepo/issues/108)) ([2fc1e1f](https://github.com/daniel-rose/monorepo/commit/2fc1e1f5d59324086a97119dcae1844edbaa8dd3))
+* add request deduplication for EnvexProvider endpoint fetching ([#108](https://github.com/daniel-rose/monorepo/issues/108)) ([2fc1e1f](https://github.com/daniel-rose/monorepo/commit/2fc1e1f5d59324086a97119dcae1844edbaa8dd3))
 
 # @daniel-rose/envex [1.3.0](https://github.com/daniel-rose/envex/compare/@daniel-rose/envex@1.2.0...@daniel-rose/envex@1.3.0) (2025-12-13)
 

--- a/packages/envex/README.md
+++ b/packages/envex/README.md
@@ -318,7 +318,7 @@ try {
 
 ### `EnvexProvider`
 
-| Prop            | Type                                  | Default          | Description                                                                                              |
+| Prop            | Type                                  | Default          | Description                                                                                             |
 | --------------- | ------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------- |
 | `initialEnv`    | `Record<string, string \| undefined>` | `{}`             | Initial env for SSR hydration (Next.js). Optional for non-SSR setups.                                   |
 | `prefix`        | `string \| null`                      | `'NEXT_PUBLIC_'` | Filter prefix for `initialEnv`. Set to `null` to pass all variables through.                            |
@@ -349,11 +349,11 @@ Creates a Next.js route handler that returns public environment variables as JSO
 
 ### `getEnv` / `getPublicEnv`
 
-| Option   | Type               | Default     | Description                                             |
-| -------- | ------------------ | ----------- | ------------------------------------------------------- |
-| `schema` | `StandardSchemaV1` | `undefined` | Validates the env and returns the schema's output type. |
+| Option   | Type               | Default     | Description                                                                                                                                                                                                                                                                                                                                |
+| -------- | ------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `schema` | `StandardSchemaV1` | `undefined` | Validates the env and returns the schema's output type.                                                                                                                                                                                                                                                                                    |
 | `prefix` | `string \| null`   | `undefined` | **`getPublicEnv` only.** Filters returned keys to those starting with the given prefix. When `null` or `undefined`, no prefix filtering is applied and all public env keys are returned. Use this to restrict which variables are exposed — only keys matching the prefix are included, reducing the risk of leaking unintended variables. |
-| `scan`   | `ScanConfig`       | `undefined` | Enable credential scanning (see below). Off by default. |
+| `scan`   | `ScanConfig`       | `undefined` | **`getPublicEnv` only.** Enable credential scanning (see below). Off by default.                                                                                                                                                                                                                                                           |
 
 ### `EnvScript` / `InlineEnvScript`
 

--- a/packages/envex/README.md
+++ b/packages/envex/README.md
@@ -8,7 +8,7 @@
 Envex provides runtime access to environment variables in React applications via `window.ENV`.
 This follows the **"build once, deploy many"** principle — the same build can be used across different environments without rebuilding.
 
-Works with **Next.js** out of the box and with **any backend** (PHP, Python, Ruby, Go, etc.) that can render a `<script>` tag.
+Works with **Next.js** out of the box and with **any backend** (PHP, Python, Ruby, Go, etc.) that can render a `<script>` tag. Supports optional schema validation via any [Standard Schema](https://standardschema.dev)-compatible library (Zod, Valibot, ArkType, and more).
 
 ## Installation
 
@@ -197,30 +197,178 @@ strategy is also exported as `nativeFetchStrategy` if you want to compose with i
 prop may be an inline arrow function; it is read via a ref, so it never triggers a refetch on
 re-render (a refetch only happens when `endpoint` changes).
 
+## Validation
+
+Envex supports optional schema validation via any library that implements the [Standard Schema](https://standardschema.dev) spec — including **Zod**, **Valibot**, **ArkType**, and **Effect Schema**.
+
+When a schema is provided, envex validates the environment variables before making them available. If validation fails, an `EnvexValidationError` is thrown with the list of issues.
+
+### Setup with Zod
+
+```bash
+npm install zod
+```
+
+Define your schema in a shared module:
+
+```ts
+// app/env.ts
+import { z } from 'zod'
+
+export const envSchema = z.object({
+  NEXT_PUBLIC_API_URL: z.string().url(),
+  NEXT_PUBLIC_FEATURE_X: z.coerce.boolean().default(false),
+})
+
+export type AppEnv = z.output<typeof envSchema>
+```
+
+### Server-side validation (Next.js)
+
+Pass the schema to server utilities — validation runs before the env is serialized or returned:
+
+```tsx
+// app/layout.tsx
+import { EnvScript } from '@daniel-rose/envex/script'
+import { EnvexProvider } from '@daniel-rose/envex'
+import { getPublicEnv } from '@daniel-rose/envex/server'
+import { envSchema } from './env'
+
+export default async function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const initialEnv = await getPublicEnv({ schema: envSchema })
+
+  return (
+    <html lang='en'>
+      <body>
+        <EnvScript schema={envSchema} />
+        <EnvexProvider initialEnv={initialEnv}>{children}</EnvexProvider>
+      </body>
+    </html>
+  )
+}
+```
+
+```ts
+// app/api/env/route.ts
+import { createEnvRouteHandler } from '@daniel-rose/envex/server'
+import { envSchema } from '../env'
+
+export const GET = createEnvRouteHandler({ schema: envSchema })
+```
+
+### Client-side validation
+
+Pass the schema to `EnvexProvider` — validation runs on every env source (`window.ENV`, `initialEnv`, or fetched endpoint response):
+
+```tsx
+import { EnvexProvider } from '@daniel-rose/envex'
+import { envSchema } from './env'
+
+;<EnvexProvider schema={envSchema}>
+  <App />
+</EnvexProvider>
+```
+
+### Type-safe access with `useEnv`
+
+Use the generic overload to get the inferred output type from your schema:
+
+```tsx
+import { useEnv } from '@daniel-rose/envex'
+import type { AppEnv } from './env'
+
+export function ApiUrl() {
+  const env = useEnv<typeof envSchema>()
+  //    ^? AppEnv — fully typed, e.g. env.NEXT_PUBLIC_API_URL is string
+  return <span>{env.NEXT_PUBLIC_API_URL}</span>
+}
+```
+
+Or create a typed wrapper hook in your app:
+
+```ts
+// app/useAppEnv.ts
+import { useEnv } from '@daniel-rose/envex'
+import type { AppEnv } from './env'
+
+export const useAppEnv = () => useEnv<typeof envSchema>()
+```
+
+### Error handling
+
+`EnvexValidationError` is thrown when validation fails. Catch it in an [Error Boundary](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) for graceful degradation:
+
+```ts
+import { EnvexValidationError } from '@daniel-rose/envex'
+
+try {
+  const env = await getPublicEnv({ schema: envSchema })
+} catch (error) {
+  if (error instanceof EnvexValidationError) {
+    console.error(error.issues) // StandardSchemaV1.Issue[]
+  }
+}
+```
+
 ## API
 
 ### `EnvexProvider`
 
-| Prop            | Type                                  | Default          | Description                                                                                     |
-| --------------- | ------------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------- |
-| `initialEnv`    | `Record<string, string \| undefined>` | `{}`             | Initial env for SSR hydration (Next.js). Optional for non-SSR setups.                           |
-| `prefix`        | `string \| null`                      | `'NEXT_PUBLIC_'` | Filter prefix for `initialEnv`. Set to `null` to pass all variables through.                    |
-| `endpoint`      | `string`                              | —                | Fetch env vars from a REST endpoint instead of `window.ENV`. When set, `window.ENV` is ignored. |
-| `fetchStrategy` | `(endpoint: string) => Promise<Env>`  | —                | Custom fetcher; overrides the native fetch. Owns its own dedup/caching.                         |
-| `children`      | `ReactNode`                           | —                | Required                                                                                        |
+| Prop            | Type                                  | Default          | Description                                                                                              |
+| --------------- | ------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------- |
+| `initialEnv`    | `Record<string, string \| undefined>` | `{}`             | Initial env for SSR hydration (Next.js). Optional for non-SSR setups.                                   |
+| `prefix`        | `string \| null`                      | `'NEXT_PUBLIC_'` | Filter prefix for `initialEnv`. Set to `null` to pass all variables through.                            |
+| `endpoint`      | `string`                              | —                | Fetch env vars from a REST endpoint instead of `window.ENV`. When set, `window.ENV` is ignored.         |
+| `fetchStrategy` | `(endpoint: string) => Promise<Env>`  | —                | Custom fetcher; overrides the native fetch. Owns its own dedup/caching.                                 |
+| `schema`        | `StandardSchemaV1`                    | —                | Optional schema. Validates `window.ENV` and fetched payloads. Throws `EnvexValidationError` on failure. |
+| `children`      | `ReactNode`                           | —                | Required                                                                                                |
 
 ### `useEnv`
 
 Returns the current environment variables as `Record<string, string | undefined>`. Must be used within an `EnvexProvider`.
 
+Accepts an optional generic for type inference when a schema is used:
+
+```ts
+const env = useEnv<typeof envSchema>() // returns StandardSchemaV1.InferOutput<typeof envSchema>
+```
+
 ### `createEnvRouteHandler`
 
 Creates a Next.js route handler that returns public environment variables as JSON. Requires Next.js.
 
-| Option   | Type         | Default     | Description                                             |
-| -------- | ------------ | ----------- | ------------------------------------------------------- |
-| `maxAge` | `number`     | `undefined` | Sets `Cache-Control: public, max-age=<value>` header.   |
-| `scan`   | `ScanConfig` | `undefined` | Enable credential scanning (see below). Off by default. |
+| Option   | Type               | Default     | Description                                             |
+| -------- | ------------------ | ----------- | ------------------------------------------------------- |
+| `maxAge` | `number`           | `undefined` | Sets `Cache-Control: public, max-age=<value>` header.   |
+| `schema` | `StandardSchemaV1` | `undefined` | Validates env before serializing the response.          |
+| `scan`   | `ScanConfig`       | `undefined` | Enable credential scanning (see below). Off by default. |
+
+### `getEnv` / `getPublicEnv`
+
+| Option   | Type               | Default     | Description                                             |
+| -------- | ------------------ | ----------- | ------------------------------------------------------- |
+| `schema` | `StandardSchemaV1` | `undefined` | Validates the env and returns the schema's output type. |
+| `scan`   | `ScanConfig`       | `undefined` | Enable credential scanning (see below). Off by default. |
+
+### `EnvScript` / `InlineEnvScript`
+
+| Prop     | Type               | Default | Description                                                |
+| -------- | ------------------ | ------- | ---------------------------------------------------------- |
+| `schema` | `StandardSchemaV1` | —       | Validates public env before serializing into `window.ENV`. |
+| `scan`   | `ScanConfig`       | —       | Enable credential scanning (see below). Off by default.    |
+
+### `EnvexValidationError`
+
+Thrown when schema validation fails. Extends `Error`.
+
+| Property  | Type                       | Description                           |
+| --------- | -------------------------- | ------------------------------------- |
+| `issues`  | `StandardSchemaV1.Issue[]` | The list of validation issues.        |
+| `message` | `string`                   | Human-readable summary of all issues. |
 
 ## Credential scanning
 
@@ -239,7 +387,7 @@ server-side emission point by passing `scan`:
 ```tsx
 ;<EnvScript scan /> // built-in engine, default settings
 export const GET = createEnvRouteHandler({ scan: true })
-const env = await getPublicEnv(true)
+const env = await getPublicEnv({ scan: true })
 ```
 
 It is only meaningful server-side; `EnvexProvider` (client) never scans, since by then the value
@@ -279,7 +427,7 @@ Two engines, selectable via `scan.engine`:
 ```
 
 The `scan` option is accepted by `EnvScript`, `InlineEnvScript`, `createEnvRouteHandler({ scan })`,
-`getPublicEnv(scan)` and `getPublicEnvByName(name, scan)`. The primitives `scanForCredentials(env, options)`
+`getPublicEnv({ scan })` and `getPublicEnvByName(name, scan)`. The primitives `scanForCredentials(env, options)`
 (sync, built-in) and `assertNoCredentialLeak(env, scan)` (async, engine-aware) are also exported for
 running the scan yourself.
 

--- a/packages/envex/README.md
+++ b/packages/envex/README.md
@@ -8,7 +8,7 @@
 Envex provides runtime access to environment variables in React applications via `window.ENV`.
 This follows the **"build once, deploy many"** principle — the same build can be used across different environments without rebuilding.
 
-Works with **Next.js** out of the box and with **any backend** (PHP, Python, Ruby, Go, etc.) that can render a `<script>` tag.
+Works with **Next.js** out of the box and with **any backend** (PHP, Python, Ruby, Go, etc.) that can render a `<script>` tag. Supports optional schema validation via any [Standard Schema](https://standardschema.dev)-compatible library (Zod, Valibot, ArkType, and more).
 
 ## Installation
 
@@ -153,28 +153,174 @@ Alternatively, use the `endpoint` prop to fetch env vars from a REST API instead
 
 This is useful for micro-frontends or SPAs that don't control the host page's script tags. When `endpoint` is set, `window.ENV` is ignored.
 
+## Validation
+
+Envex supports optional schema validation via any library that implements the [Standard Schema](https://standardschema.dev) spec — including **Zod**, **Valibot**, **ArkType**, and **Effect Schema**.
+
+When a schema is provided, envex validates the environment variables before making them available. If validation fails, an `EnvexValidationError` is thrown with the list of issues.
+
+### Setup with Zod
+
+```bash
+npm install zod
+```
+
+Define your schema in a shared module:
+
+```ts
+// app/env.ts
+import { z } from 'zod'
+
+export const envSchema = z.object({
+  NEXT_PUBLIC_API_URL: z.string().url(),
+  NEXT_PUBLIC_FEATURE_X: z.coerce.boolean().default(false),
+})
+
+export type AppEnv = z.output<typeof envSchema>
+```
+
+### Server-side validation (Next.js)
+
+Pass the schema to server utilities — validation runs before the env is serialized or returned:
+
+```tsx
+// app/layout.tsx
+import { EnvScript } from '@daniel-rose/envex/script'
+import { EnvexProvider } from '@daniel-rose/envex'
+import { getPublicEnv } from '@daniel-rose/envex/server'
+import { envSchema } from './env'
+
+export default async function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const initialEnv = await getPublicEnv({ schema: envSchema })
+
+  return (
+    <html lang='en'>
+      <body>
+        <EnvScript schema={envSchema} />
+        <EnvexProvider initialEnv={initialEnv}>{children}</EnvexProvider>
+      </body>
+    </html>
+  )
+}
+```
+
+```ts
+// app/api/env/route.ts
+import { createEnvRouteHandler } from '@daniel-rose/envex/server'
+import { envSchema } from '../env'
+
+export const GET = createEnvRouteHandler({ schema: envSchema })
+```
+
+### Client-side validation
+
+Pass the schema to `EnvexProvider` — validation runs on every env source (`window.ENV`, `initialEnv`, or fetched endpoint response):
+
+```tsx
+import { EnvexProvider } from '@daniel-rose/envex'
+import { envSchema } from './env'
+
+;<EnvexProvider schema={envSchema}>
+  <App />
+</EnvexProvider>
+```
+
+### Type-safe access with `useEnv`
+
+Use the generic overload to get the inferred output type from your schema:
+
+```tsx
+import { useEnv } from '@daniel-rose/envex'
+import type { AppEnv } from './env'
+
+export function ApiUrl() {
+  const env = useEnv<typeof envSchema>()
+  //    ^? AppEnv — fully typed, e.g. env.NEXT_PUBLIC_API_URL is string
+  return <span>{env.NEXT_PUBLIC_API_URL}</span>
+}
+```
+
+Or create a typed wrapper hook in your app:
+
+```ts
+// app/useAppEnv.ts
+import { useEnv } from '@daniel-rose/envex'
+import type { AppEnv } from './env'
+
+export const useAppEnv = () => useEnv<typeof envSchema>()
+```
+
+### Error handling
+
+`EnvexValidationError` is thrown when validation fails. Catch it in an [Error Boundary](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) for graceful degradation:
+
+```ts
+import { EnvexValidationError } from '@daniel-rose/envex'
+
+try {
+  const env = await getPublicEnv({ schema: envSchema })
+} catch (error) {
+  if (error instanceof EnvexValidationError) {
+    console.error(error.issues) // StandardSchemaV1.Issue[]
+  }
+}
+```
+
 ## API
 
 ### `EnvexProvider`
 
-| Prop         | Type                                  | Default          | Description                                                                                     |
-| ------------ | ------------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------- |
-| `initialEnv` | `Record<string, string \| undefined>` | `{}`             | Initial env for SSR hydration (Next.js). Optional for non-SSR setups.                           |
-| `prefix`     | `string \| null`                      | `'NEXT_PUBLIC_'` | Filter prefix for `initialEnv`. Set to `null` to pass all variables through.                    |
-| `endpoint`   | `string`                              | —                | Fetch env vars from a REST endpoint instead of `window.ENV`. When set, `window.ENV` is ignored. |
-| `children`   | `ReactNode`                           | —                | Required                                                                                        |
+| Prop         | Type                                  | Default          | Description                                                                                             |
+| ------------ | ------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------- |
+| `initialEnv` | `Record<string, string \| undefined>` | `{}`             | Initial env for SSR hydration (Next.js). Optional for non-SSR setups.                                   |
+| `prefix`     | `string \| null`                      | `'NEXT_PUBLIC_'` | Filter prefix for `initialEnv`. Set to `null` to pass all variables through.                            |
+| `endpoint`   | `string`                              | —                | Fetch env vars from a REST endpoint instead of `window.ENV`. When set, `window.ENV` is ignored.         |
+| `schema`     | `StandardSchemaV1`                    | —                | Optional schema. Validates `window.ENV` and fetched payloads. Throws `EnvexValidationError` on failure. |
+| `children`   | `ReactNode`                           | —                | Required                                                                                                |
 
 ### `useEnv`
 
 Returns the current environment variables as `Record<string, string | undefined>`. Must be used within an `EnvexProvider`.
 
+Accepts an optional generic for type inference when a schema is used:
+
+```ts
+const env = useEnv<typeof envSchema>() // returns StandardSchemaV1.InferOutput<typeof envSchema>
+```
+
 ### `createEnvRouteHandler`
 
 Creates a Next.js route handler that returns public environment variables as JSON. Requires Next.js.
 
-| Option   | Type     | Default     | Description                                           |
-| -------- | -------- | ----------- | ----------------------------------------------------- |
-| `maxAge` | `number` | `undefined` | Sets `Cache-Control: public, max-age=<value>` header. |
+| Option   | Type               | Default     | Description                                           |
+| -------- | ------------------ | ----------- | ----------------------------------------------------- |
+| `maxAge` | `number`           | `undefined` | Sets `Cache-Control: public, max-age=<value>` header. |
+| `schema` | `StandardSchemaV1` | `undefined` | Validates env before serializing the response.        |
+
+### `getEnv` / `getPublicEnv`
+
+| Option   | Type               | Default     | Description                                             |
+| -------- | ------------------ | ----------- | ------------------------------------------------------- |
+| `schema` | `StandardSchemaV1` | `undefined` | Validates the env and returns the schema's output type. |
+
+### `EnvScript` / `InlineEnvScript`
+
+| Prop     | Type               | Default | Description                                                |
+| -------- | ------------------ | ------- | ---------------------------------------------------------- |
+| `schema` | `StandardSchemaV1` | —       | Validates public env before serializing into `window.ENV`. |
+
+### `EnvexValidationError`
+
+Thrown when schema validation fails. Extends `Error`.
+
+| Property  | Type                       | Description                           |
+| --------- | -------------------------- | ------------------------------------- |
+| `issues`  | `StandardSchemaV1.Issue[]` | The list of validation issues.        |
+| `message` | `string`                   | Human-readable summary of all issues. |
 
 ## Example
 

--- a/packages/envex/README.md
+++ b/packages/envex/README.md
@@ -352,6 +352,7 @@ Creates a Next.js route handler that returns public environment variables as JSO
 | Option   | Type               | Default     | Description                                             |
 | -------- | ------------------ | ----------- | ------------------------------------------------------- |
 | `schema` | `StandardSchemaV1` | `undefined` | Validates the env and returns the schema's output type. |
+| `prefix` | `string \| null`   | `undefined` | **`getPublicEnv` only.** Filters returned keys to those starting with the given prefix. When `null` or `undefined`, no prefix filtering is applied and all public env keys are returned. Use this to restrict which variables are exposed — only keys matching the prefix are included, reducing the risk of leaking unintended variables. |
 | `scan`   | `ScanConfig`       | `undefined` | Enable credential scanning (see below). Off by default. |
 
 ### `EnvScript` / `InlineEnvScript`

--- a/packages/envex/README.md
+++ b/packages/envex/README.md
@@ -262,7 +262,7 @@ export const GET = createEnvRouteHandler({ schema: envSchema })
 
 ### Client-side validation
 
-Pass the schema to `EnvexProvider` — validation runs on every env source (`window.ENV`, `initialEnv`, or fetched endpoint response):
+Pass the schema to `EnvexProvider` — validation runs on `window.ENV` or the fetched endpoint response:
 
 ```tsx
 import { EnvexProvider } from '@daniel-rose/envex'

--- a/packages/envex/README.md
+++ b/packages/envex/README.md
@@ -306,6 +306,7 @@ Creates a Next.js route handler that returns public environment variables as JSO
 | Option   | Type               | Default     | Description                                             |
 | -------- | ------------------ | ----------- | ------------------------------------------------------- |
 | `schema` | `StandardSchemaV1` | `undefined` | Validates the env and returns the schema's output type. |
+| `prefix` | `string \| null`   | `undefined` | **`getPublicEnv` only.** Filters returned keys to those starting with the given prefix. When `null` or `undefined`, no prefix filtering is applied and all public env keys are returned. Use this to restrict which variables are exposed — only keys matching the prefix are included, reducing the risk of leaking unintended variables. |
 
 ### `EnvScript` / `InlineEnvScript`
 

--- a/packages/envex/README.md
+++ b/packages/envex/README.md
@@ -218,7 +218,7 @@ export const GET = createEnvRouteHandler({ schema: envSchema })
 
 ### Client-side validation
 
-Pass the schema to `EnvexProvider` — validation runs on every env source (`window.ENV`, `initialEnv`, or fetched endpoint response):
+Pass the schema to `EnvexProvider` — validation runs on `window.ENV` or the fetched endpoint response:
 
 ```tsx
 import { EnvexProvider } from '@daniel-rose/envex'

--- a/packages/envex/eslint.config.js
+++ b/packages/envex/eslint.config.js
@@ -1,3 +1,3 @@
 import { reactConfig } from '@daniel-rose/eslint-config/react'
 
-export default [...reactConfig]
+export default [...reactConfig, { ignores: ['coverage'] }]

--- a/packages/envex/package.json
+++ b/packages/envex/package.json
@@ -92,5 +92,8 @@
   "bugs": {
     "url": "https://github.com/daniel-rose/monorepo/issues"
   },
-  "homepage": "https://github.com/daniel-rose/monorepo/blob/main/packages/envex/README.md"
+  "homepage": "https://github.com/daniel-rose/monorepo/blob/main/packages/envex/README.md",
+  "dependencies": {
+    "@standard-schema/spec": "^1.1.0"
+  }
 }

--- a/packages/envex/package.json
+++ b/packages/envex/package.json
@@ -102,5 +102,8 @@
   "bugs": {
     "url": "https://github.com/daniel-rose/monorepo/issues"
   },
-  "homepage": "https://github.com/daniel-rose/monorepo/blob/main/packages/envex/README.md"
+  "homepage": "https://github.com/daniel-rose/monorepo/blob/main/packages/envex/README.md",
+  "dependencies": {
+    "@standard-schema/spec": "^1.1.0"
+  }
 }

--- a/packages/envex/src/errors.ts
+++ b/packages/envex/src/errors.ts
@@ -1,3 +1,4 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 import type { CredentialFinding } from './types.ts'
 
 /** @deprecated Use EnvexWindowEnvIsMissingError instead */
@@ -19,5 +20,22 @@ export class EnvexCredentialLeakError extends Error {
     )
     this.name = 'EnvexCredentialLeakError'
     this.findings = findings
+  }
+}
+
+export class EnvexValidationError extends Error {
+  readonly issues: readonly StandardSchemaV1.Issue[]
+
+  constructor(issues: readonly StandardSchemaV1.Issue[]) {
+    super(
+      `Environment validation failed: ${issues
+        .map(
+          i =>
+            `[${(i.path ?? []).map(p => (typeof p === 'object' ? p.key : p)).join('.')}] ${i.message}`
+        )
+        .join('; ')}`
+    )
+    this.name = 'EnvexValidationError'
+    this.issues = issues
   }
 }

--- a/packages/envex/src/errors.ts
+++ b/packages/envex/src/errors.ts
@@ -1,6 +1,25 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
+
 /** @deprecated Use EnvexWindowEnvIsMissingError instead */
 export class EnvexScriptIsMissingError extends Error {}
 
 export class EnvexWindowEnvIsMissingError extends EnvexScriptIsMissingError {}
 
 export class EnvexProviderIsMissingError extends Error {}
+
+export class EnvexValidationError extends Error {
+  readonly issues: readonly StandardSchemaV1.Issue[]
+
+  constructor(issues: readonly StandardSchemaV1.Issue[]) {
+    super(
+      `Environment validation failed: ${issues
+        .map(
+          i =>
+            `[${(i.path ?? []).map(p => (typeof p === 'object' ? p.key : p)).join('.')}] ${i.message}`
+        )
+        .join('; ')}`
+    )
+    this.name = 'EnvexValidationError'
+    this.issues = issues
+  }
+}

--- a/packages/envex/src/nextjs/EnvScript/index.tsx
+++ b/packages/envex/src/nextjs/EnvScript/index.tsx
@@ -1,10 +1,6 @@
-import type { StandardSchemaV1 } from '@standard-schema/spec'
 import Script from 'next/script'
 import { getPublicEnv } from '../utils'
-
-interface EnvScriptProps {
-  schema?: StandardSchemaV1
-}
+import type { EnvScriptProps } from './types'
 
 const EnvScript = async ({ schema }: EnvScriptProps = {}) => {
   const env = await getPublicEnv({ schema })

--- a/packages/envex/src/nextjs/EnvScript/index.tsx
+++ b/packages/envex/src/nextjs/EnvScript/index.tsx
@@ -1,6 +1,6 @@
 import Script from 'next/script'
 import { getPublicEnv } from '../utils'
-import type { EnvScriptProps } from './types.ts'
+import type { EnvScriptProps } from './types'
 
 const EnvScript = async ({ scan, schema }: EnvScriptProps = {}) => {
   const env = await getPublicEnv({ scan, schema })

--- a/packages/envex/src/nextjs/EnvScript/index.tsx
+++ b/packages/envex/src/nextjs/EnvScript/index.tsx
@@ -1,8 +1,13 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 import Script from 'next/script'
 import { getPublicEnv } from '../utils'
 
-const EnvScript = async () => {
-  const env = await getPublicEnv()
+interface EnvScriptProps {
+  schema?: StandardSchemaV1
+}
+
+const EnvScript = async ({ schema }: EnvScriptProps = {}) => {
+  const env = await getPublicEnv({ schema })
 
   const innerHTML = {
     __html: `window.ENV = ${JSON.stringify(env)}`,

--- a/packages/envex/src/nextjs/EnvScript/index.tsx
+++ b/packages/envex/src/nextjs/EnvScript/index.tsx
@@ -2,8 +2,8 @@ import Script from 'next/script'
 import { getPublicEnv } from '../utils'
 import type { EnvScriptProps } from './types.ts'
 
-const EnvScript = async ({ scan }: EnvScriptProps = {}) => {
-  const env = await getPublicEnv(scan)
+const EnvScript = async ({ scan, schema }: EnvScriptProps = {}) => {
+  const env = await getPublicEnv({ scan, schema })
 
   const innerHTML = {
     __html: `window.ENV = ${JSON.stringify(env)}`,

--- a/packages/envex/src/nextjs/EnvScript/types.ts
+++ b/packages/envex/src/nextjs/EnvScript/types.ts
@@ -1,6 +1,8 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 import type { ScanConfig } from '../../types.ts'
 
 export interface EnvScriptProps {
   /** Enable credential scanning: `true` for defaults or a config object. Off by default. */
   scan?: ScanConfig
+  schema?: StandardSchemaV1
 }

--- a/packages/envex/src/nextjs/EnvScript/types.ts
+++ b/packages/envex/src/nextjs/EnvScript/types.ts
@@ -1,0 +1,1 @@
+export type { EnvScriptProps } from '../types'

--- a/packages/envex/src/nextjs/EnvScript/types.ts
+++ b/packages/envex/src/nextjs/EnvScript/types.ts
@@ -1,8 +1,1 @@
-import type { StandardSchemaV1 } from '@standard-schema/spec'
-import type { ScanConfig } from '../../types.ts'
-
-export interface EnvScriptProps {
-  /** Enable credential scanning: `true` for defaults or a config object. Off by default. */
-  scan?: ScanConfig
-  schema?: StandardSchemaV1
-}
+export type { EnvScriptProps } from '../types'

--- a/packages/envex/src/nextjs/InlineEnvScript/index.tsx
+++ b/packages/envex/src/nextjs/InlineEnvScript/index.tsx
@@ -1,8 +1,8 @@
 import { getPublicEnv } from '../utils'
 import type { InlineEnvScriptProps } from './types.ts'
 
-const InlineEnvScript = async ({ scan }: InlineEnvScriptProps = {}) => {
-  const env = await getPublicEnv(scan)
+const InlineEnvScript = async ({ scan, schema }: InlineEnvScriptProps = {}) => {
+  const env = await getPublicEnv({ scan, schema })
 
   return (
     <script

--- a/packages/envex/src/nextjs/InlineEnvScript/index.tsx
+++ b/packages/envex/src/nextjs/InlineEnvScript/index.tsx
@@ -1,7 +1,12 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 import { getPublicEnv } from '../utils'
 
-const InlineEnvScript = async () => {
-  const env = await getPublicEnv()
+interface InlineEnvScriptProps {
+  schema?: StandardSchemaV1
+}
+
+const InlineEnvScript = async ({ schema }: InlineEnvScriptProps = {}) => {
+  const env = await getPublicEnv({ schema })
 
   return (
     <script

--- a/packages/envex/src/nextjs/InlineEnvScript/index.tsx
+++ b/packages/envex/src/nextjs/InlineEnvScript/index.tsx
@@ -1,9 +1,5 @@
-import type { StandardSchemaV1 } from '@standard-schema/spec'
 import { getPublicEnv } from '../utils'
-
-interface InlineEnvScriptProps {
-  schema?: StandardSchemaV1
-}
+import type { InlineEnvScriptProps } from './types'
 
 const InlineEnvScript = async ({ schema }: InlineEnvScriptProps = {}) => {
   const env = await getPublicEnv({ schema })

--- a/packages/envex/src/nextjs/InlineEnvScript/index.tsx
+++ b/packages/envex/src/nextjs/InlineEnvScript/index.tsx
@@ -1,5 +1,5 @@
 import { getPublicEnv } from '../utils'
-import type { InlineEnvScriptProps } from './types.ts'
+import type { InlineEnvScriptProps } from './types'
 
 const InlineEnvScript = async ({ scan, schema }: InlineEnvScriptProps = {}) => {
   const env = await getPublicEnv({ scan, schema })

--- a/packages/envex/src/nextjs/InlineEnvScript/types.ts
+++ b/packages/envex/src/nextjs/InlineEnvScript/types.ts
@@ -1,6 +1,8 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 import type { ScanConfig } from '../../types.ts'
 
 export interface InlineEnvScriptProps {
   /** Enable credential scanning: `true` for defaults or a config object. Off by default. */
   scan?: ScanConfig
+  schema?: StandardSchemaV1
 }

--- a/packages/envex/src/nextjs/InlineEnvScript/types.ts
+++ b/packages/envex/src/nextjs/InlineEnvScript/types.ts
@@ -1,0 +1,1 @@
+export type { EnvScriptProps as InlineEnvScriptProps } from '../types'

--- a/packages/envex/src/nextjs/InlineEnvScript/types.ts
+++ b/packages/envex/src/nextjs/InlineEnvScript/types.ts
@@ -1,8 +1,1 @@
-import type { StandardSchemaV1 } from '@standard-schema/spec'
-import type { ScanConfig } from '../../types.ts'
-
-export interface InlineEnvScriptProps {
-  /** Enable credential scanning: `true` for defaults or a config object. Off by default. */
-  scan?: ScanConfig
-  schema?: StandardSchemaV1
-}
+export type { EnvScriptProps as InlineEnvScriptProps } from '../types'

--- a/packages/envex/src/nextjs/types.ts
+++ b/packages/envex/src/nextjs/types.ts
@@ -4,5 +4,6 @@ import type { ScanConfig } from '../types.ts'
 export interface EnvScriptProps {
   /** Enable credential scanning: `true` for defaults or a config object. Off by default. */
   scan?: ScanConfig
+  /** Standard Schema to validate the public env against before serializing into `window.ENV`. */
   schema?: StandardSchemaV1
 }

--- a/packages/envex/src/nextjs/types.ts
+++ b/packages/envex/src/nextjs/types.ts
@@ -1,0 +1,8 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
+import type { ScanConfig } from '../types.ts'
+
+export interface EnvScriptProps {
+  /** Enable credential scanning: `true` for defaults or a config object. Off by default. */
+  scan?: ScanConfig
+  schema?: StandardSchemaV1
+}

--- a/packages/envex/src/nextjs/types.ts
+++ b/packages/envex/src/nextjs/types.ts
@@ -1,0 +1,5 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
+
+export interface EnvScriptProps {
+  schema?: StandardSchemaV1
+}

--- a/packages/envex/src/nextjs/utils/createEnvRouteHandler/index.ts
+++ b/packages/envex/src/nextjs/utils/createEnvRouteHandler/index.ts
@@ -1,12 +1,17 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 import { NextResponse } from 'next/server'
 import { getPublicEnv } from '../'
 import type { EnvRouteHandlerOptions } from './types.ts'
 
-const createEnvRouteHandler = (options: EnvRouteHandlerOptions = {}) => {
-  const { maxAge } = options
+const createEnvRouteHandler = <
+  TSchema extends StandardSchemaV1 | undefined = undefined,
+>(
+  options: EnvRouteHandlerOptions<TSchema> = {}
+) => {
+  const { maxAge, schema } = options
 
   return async () => {
-    const env = await getPublicEnv()
+    const env = await getPublicEnv({ schema })
 
     const headers: HeadersInit = {}
 

--- a/packages/envex/src/nextjs/utils/createEnvRouteHandler/index.ts
+++ b/packages/envex/src/nextjs/utils/createEnvRouteHandler/index.ts
@@ -1,12 +1,17 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 import { NextResponse } from 'next/server'
 import { getPublicEnv } from '../'
 import type { EnvRouteHandlerOptions } from './types.ts'
 
-const createEnvRouteHandler = (options: EnvRouteHandlerOptions = {}) => {
-  const { maxAge, scan } = options
+const createEnvRouteHandler = <
+  TSchema extends StandardSchemaV1 | undefined = undefined,
+>(
+  options: EnvRouteHandlerOptions<TSchema> = {}
+) => {
+  const { maxAge, schema, scan } = options
 
   return async () => {
-    const env = await getPublicEnv(scan)
+    const env = await getPublicEnv({ schema, scan })
 
     const headers: HeadersInit = {}
 

--- a/packages/envex/src/nextjs/utils/createEnvRouteHandler/types.ts
+++ b/packages/envex/src/nextjs/utils/createEnvRouteHandler/types.ts
@@ -1,3 +1,8 @@
-export interface EnvRouteHandlerOptions {
+import type { StandardSchemaV1 } from '@standard-schema/spec'
+
+export interface EnvRouteHandlerOptions<
+  TSchema extends StandardSchemaV1 | undefined = undefined,
+> {
   maxAge?: number
+  schema?: TSchema
 }

--- a/packages/envex/src/nextjs/utils/createEnvRouteHandler/types.ts
+++ b/packages/envex/src/nextjs/utils/createEnvRouteHandler/types.ts
@@ -1,7 +1,11 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 import type { ScanConfig } from '../../../types.ts'
 
-export interface EnvRouteHandlerOptions {
+export interface EnvRouteHandlerOptions<
+  TSchema extends StandardSchemaV1 | undefined = undefined,
+> {
   maxAge?: number
+  schema?: TSchema
   /** Enable credential scanning: `true` for defaults or a config object. Off by default. */
   scan?: ScanConfig
 }

--- a/packages/envex/src/nextjs/utils/getEnv/index.ts
+++ b/packages/envex/src/nextjs/utils/getEnv/index.ts
@@ -2,12 +2,7 @@ import type { StandardSchemaV1 } from '@standard-schema/spec'
 import { connection } from 'next/server'
 import type { Env } from '../../../types.ts'
 import { validateEnv } from '../../../utils'
-
-export interface GetEnvOptions<
-  TSchema extends StandardSchemaV1 | undefined = undefined,
-> {
-  schema?: TSchema
-}
+import type { GetEnvOptions } from './types.ts'
 
 const getEnv = async <TSchema extends StandardSchemaV1 | undefined = undefined>(
   options?: GetEnvOptions<TSchema>

--- a/packages/envex/src/nextjs/utils/getEnv/index.ts
+++ b/packages/envex/src/nextjs/utils/getEnv/index.ts
@@ -1,10 +1,26 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 import { connection } from 'next/server'
 import type { Env } from '../../../types.ts'
+import { validateEnv } from '../../../utils'
 
-const getEnv = async (): Promise<Env> => {
+export interface GetEnvOptions<
+  TSchema extends StandardSchemaV1 | undefined = undefined,
+> {
+  schema?: TSchema
+}
+
+const getEnv = async <TSchema extends StandardSchemaV1 | undefined = undefined>(
+  options?: GetEnvOptions<TSchema>
+): Promise<
+  TSchema extends StandardSchemaV1 ? StandardSchemaV1.InferOutput<TSchema> : Env
+> => {
   await connection()
 
-  return process.env
+  if (options?.schema) {
+    return validateEnv(options.schema, process.env) as never
+  }
+
+  return process.env as never
 }
 
 export default getEnv

--- a/packages/envex/src/nextjs/utils/getEnv/types.ts
+++ b/packages/envex/src/nextjs/utils/getEnv/types.ts
@@ -1,0 +1,7 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
+
+export interface GetEnvOptions<
+  TSchema extends StandardSchemaV1 | undefined = undefined,
+> {
+  schema?: TSchema
+}

--- a/packages/envex/src/nextjs/utils/getPublicEnv/index.ts
+++ b/packages/envex/src/nextjs/utils/getPublicEnv/index.ts
@@ -2,13 +2,7 @@ import type { StandardSchemaV1 } from '@standard-schema/spec'
 import { getEnv } from '../'
 import type { Env } from '../../../types.ts'
 import { filterPublicEnv, validateEnv } from '../../../utils'
-
-export interface GetPublicEnvOptions<
-  TSchema extends StandardSchemaV1 | undefined = undefined,
-> {
-  schema?: TSchema
-  prefix?: string | null
-}
+import type { GetPublicEnvOptions } from './types.ts'
 
 const getPublicEnv = async <
   TSchema extends StandardSchemaV1 | undefined = undefined,

--- a/packages/envex/src/nextjs/utils/getPublicEnv/index.ts
+++ b/packages/envex/src/nextjs/utils/getPublicEnv/index.ts
@@ -1,20 +1,12 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec'
 import { getEnv } from '../'
-import type { Env, ScanConfig } from '../../../types.ts'
+import type { Env } from '../../../types.ts'
 import {
   assertNoCredentialLeak,
   filterPublicEnv,
   validateEnv,
 } from '../../../utils'
-
-export interface GetPublicEnvOptions<
-  TSchema extends StandardSchemaV1 | undefined = undefined,
-> {
-  schema?: TSchema
-  prefix?: string | null
-  /** Enable credential scanning: `true` for defaults or a config object. Off by default. */
-  scan?: ScanConfig
-}
+import type { GetPublicEnvOptions } from './types.ts'
 
 const getPublicEnv = async <
   TSchema extends StandardSchemaV1 | undefined = undefined,

--- a/packages/envex/src/nextjs/utils/getPublicEnv/index.ts
+++ b/packages/envex/src/nextjs/utils/getPublicEnv/index.ts
@@ -1,11 +1,30 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 import { getEnv } from '../'
 import type { Env } from '../../../types.ts'
-import { filterPublicEnv } from '../../../utils'
+import { filterPublicEnv, validateEnv } from '../../../utils'
 
-const getPublicEnv = async (): Promise<Env> => {
+export interface GetPublicEnvOptions<
+  TSchema extends StandardSchemaV1 | undefined = undefined,
+> {
+  schema?: TSchema
+  prefix?: string | null
+}
+
+const getPublicEnv = async <
+  TSchema extends StandardSchemaV1 | undefined = undefined,
+>(
+  options?: GetPublicEnvOptions<TSchema>
+): Promise<
+  TSchema extends StandardSchemaV1 ? StandardSchemaV1.InferOutput<TSchema> : Env
+> => {
   const env = await getEnv()
+  const filtered = filterPublicEnv(env, options?.prefix)
 
-  return filterPublicEnv(env)
+  if (options?.schema) {
+    return validateEnv(options.schema, filtered) as never
+  }
+
+  return filtered as never
 }
 
 export default getPublicEnv

--- a/packages/envex/src/nextjs/utils/getPublicEnv/index.ts
+++ b/packages/envex/src/nextjs/utils/getPublicEnv/index.ts
@@ -1,13 +1,38 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 import { getEnv } from '../'
 import type { Env, ScanConfig } from '../../../types.ts'
-import { assertNoCredentialLeak, filterPublicEnv } from '../../../utils'
+import {
+  assertNoCredentialLeak,
+  filterPublicEnv,
+  validateEnv,
+} from '../../../utils'
 
-const getPublicEnv = async (scan?: ScanConfig): Promise<Env> => {
-  const publicEnv = filterPublicEnv(await getEnv())
+export interface GetPublicEnvOptions<
+  TSchema extends StandardSchemaV1 | undefined = undefined,
+> {
+  schema?: TSchema
+  prefix?: string | null
+  /** Enable credential scanning: `true` for defaults or a config object. Off by default. */
+  scan?: ScanConfig
+}
 
-  await assertNoCredentialLeak(publicEnv, scan)
+const getPublicEnv = async <
+  TSchema extends StandardSchemaV1 | undefined = undefined,
+>(
+  options?: GetPublicEnvOptions<TSchema>
+): Promise<
+  TSchema extends StandardSchemaV1 ? StandardSchemaV1.InferOutput<TSchema> : Env
+> => {
+  const env = await getEnv()
+  const filtered = filterPublicEnv(env, options?.prefix)
 
-  return publicEnv
+  await assertNoCredentialLeak(filtered, options?.scan)
+
+  if (options?.schema) {
+    return validateEnv(options.schema, filtered) as never
+  }
+
+  return filtered as never
 }
 
 export default getPublicEnv

--- a/packages/envex/src/nextjs/utils/getPublicEnv/types.ts
+++ b/packages/envex/src/nextjs/utils/getPublicEnv/types.ts
@@ -1,0 +1,11 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
+import type { ScanConfig } from '../../../types.ts'
+
+export interface GetPublicEnvOptions<
+  TSchema extends StandardSchemaV1 | undefined = undefined,
+> {
+  schema?: TSchema
+  prefix?: string | null
+  /** Enable credential scanning: `true` for defaults or a config object. Off by default. */
+  scan?: ScanConfig
+}

--- a/packages/envex/src/nextjs/utils/getPublicEnv/types.ts
+++ b/packages/envex/src/nextjs/utils/getPublicEnv/types.ts
@@ -1,0 +1,8 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
+
+export interface GetPublicEnvOptions<
+  TSchema extends StandardSchemaV1 | undefined = undefined,
+> {
+  schema?: TSchema
+  prefix?: string | null
+}

--- a/packages/envex/src/nextjs/utils/getPublicEnvByName/index.ts
+++ b/packages/envex/src/nextjs/utils/getPublicEnvByName/index.ts
@@ -5,7 +5,7 @@ const getPublicEnvByName = async (
   name: string,
   scan?: ScanConfig
 ): Promise<string | undefined> => {
-  const env = await getPublicEnv(scan)
+  const env = await getPublicEnv({ scan })
 
   return env[name]
 }

--- a/packages/envex/src/react/EnvexProvider/hooks/useEnv/index.ts
+++ b/packages/envex/src/react/EnvexProvider/hooks/useEnv/index.ts
@@ -1,11 +1,18 @@
 'use client'
 
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 import { useContext } from 'react'
 import { EnvexProviderIsMissingError } from '../../../../errors.ts'
 import type { Env } from '../../../../types.ts'
 import { EnvexContext } from '../../contexts'
 
-const useEnv = (): Env => {
+function useEnv(): Env
+function useEnv<
+  TSchema extends StandardSchemaV1,
+>(): StandardSchemaV1.InferOutput<TSchema>
+function useEnv<TSchema extends StandardSchemaV1 | undefined = undefined>():
+  | Env
+  | StandardSchemaV1.InferOutput<NonNullable<TSchema>> {
   const env = useContext(EnvexContext)
 
   if (env === undefined) {

--- a/packages/envex/src/react/EnvexProvider/hooks/useEnv/index.ts
+++ b/packages/envex/src/react/EnvexProvider/hooks/useEnv/index.ts
@@ -11,8 +11,7 @@ function useEnv<
   TSchema extends StandardSchemaV1,
 >(): StandardSchemaV1.InferOutput<TSchema>
 function useEnv<TSchema extends StandardSchemaV1 | undefined = undefined>():
-  | Env
-  | StandardSchemaV1.InferOutput<NonNullable<TSchema>> {
+  Env | StandardSchemaV1.InferOutput<NonNullable<TSchema>> {
   const env = useContext(EnvexContext)
 
   if (env === undefined) {

--- a/packages/envex/src/react/EnvexProvider/index.tsx
+++ b/packages/envex/src/react/EnvexProvider/index.tsx
@@ -33,6 +33,7 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
               setError(err)
             } else {
               console.error('[envex] Failed to fetch env from endpoint:', err)
+              setError(new Error(String(err)))
             }
           }
         })
@@ -55,8 +56,13 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
         if (!isCancelled) setEnv(result as Env)
       })
       .catch((err: unknown) => {
-        if (!isCancelled && err instanceof Error) {
-          setError(err)
+        if (!isCancelled) {
+          if (err instanceof Error) {
+            setError(err)
+          } else {
+            console.error('[envex] Failed to load env from window.ENV:', err)
+            setError(new Error(String(err)))
+          }
         }
       })
 

--- a/packages/envex/src/react/EnvexProvider/index.tsx
+++ b/packages/envex/src/react/EnvexProvider/index.tsx
@@ -63,16 +63,17 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
       }
     }
 
-    if (!window.ENV || typeof window.ENV !== 'object') {
-      throw new EnvexWindowEnvIsMissingError(
-        'window.ENV is required. Use EnvScript (Next.js), set window.ENV manually via a <script> tag, or use the endpoint prop.'
-      )
-    }
-
     let isCancelled = false
-    const windowEnv = window.ENV
 
-    void Promise.resolve(schema ? validateEnv(schema, windowEnv) : windowEnv)
+    void Promise.resolve()
+      .then(() => {
+        if (!window.ENV || typeof window.ENV !== 'object') {
+          throw new EnvexWindowEnvIsMissingError(
+            'window.ENV is required. Use EnvScript (Next.js), set window.ENV manually via a <script> tag, or use the endpoint prop.'
+          )
+        }
+        return schema ? validateEnv(schema, window.ENV) : window.ENV
+      })
       .then(result => {
         if (!isCancelled) setEnv(result as Env)
       })

--- a/packages/envex/src/react/EnvexProvider/index.tsx
+++ b/packages/envex/src/react/EnvexProvider/index.tsx
@@ -24,6 +24,13 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
       : {}
   )
   const [error, setError] = useState<Error | null>(null)
+  // Without a schema every value is exposed as-is, so the provider is ready
+  // immediately. With a schema, a seeded initialEnv is the server-validated
+  // output and is safe to expose; otherwise children must wait for client-side
+  // validation so schema consumers never see an unvalidated empty object.
+  const [isReady, setIsReady] = useState<boolean>(
+    !schema || Boolean(initialEnv)
+  )
 
   if (error) throw error
 
@@ -108,10 +115,12 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
 
     void Promise.resolve(schema ? validateEnv(schema, rawEnv) : rawEnv)
       .then(result => {
-        if (!isCancelled)
+        if (!isCancelled) {
           setEnv(
             schema ? (result as Env) : filterPublicEnv(result as Env, prefix)
           )
+          setIsReady(true)
+        }
       })
       .catch((err: unknown) => {
         if (!isCancelled) {
@@ -129,7 +138,11 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
     }
   }, [rawEnv, schema, prefix])
 
-  return <EnvexContext.Provider value={env}>{children}</EnvexContext.Provider>
+  return (
+    <EnvexContext.Provider value={env}>
+      {isReady ? children : null}
+    </EnvexContext.Provider>
+  )
 }
 
 export default EnvexProvider

--- a/packages/envex/src/react/EnvexProvider/index.tsx
+++ b/packages/envex/src/react/EnvexProvider/index.tsx
@@ -12,8 +12,16 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
   const { initialEnv, prefix, endpoint, fetchStrategy, schema, children } =
     props
   const [rawEnv, setRawEnv] = useState<Env | null>(null)
+  // Seed the first paint (incl. SSR) from initialEnv. With a schema, initialEnv
+  // is already the server-validated output, so it is used as-is; otherwise it is
+  // prefix-filtered. The fetch/validation effects still refresh from window.ENV
+  // (or the endpoint) on the client.
   const [env, setEnv] = useState<Env>(
-    initialEnv && !schema ? filterPublicEnv(initialEnv, prefix) : {}
+    initialEnv
+      ? schema
+        ? initialEnv
+        : filterPublicEnv(initialEnv, prefix)
+      : {}
   )
   const [error, setError] = useState<Error | null>(null)
 

--- a/packages/envex/src/react/EnvexProvider/index.tsx
+++ b/packages/envex/src/react/EnvexProvider/index.tsx
@@ -100,7 +100,10 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
 
     void Promise.resolve(schema ? validateEnv(schema, rawEnv) : rawEnv)
       .then(result => {
-        if (!isCancelled) setEnv(result as Env)
+        if (!isCancelled)
+          setEnv(
+            schema ? (result as Env) : filterPublicEnv(result as Env, prefix)
+          )
       })
       .catch((err: unknown) => {
         if (!isCancelled) {
@@ -116,7 +119,7 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
     return () => {
       isCancelled = true
     }
-  }, [rawEnv, schema])
+  }, [rawEnv, schema, prefix])
 
   return <EnvexContext.Provider value={env}>{children}</EnvexContext.Provider>
 }

--- a/packages/envex/src/react/EnvexProvider/index.tsx
+++ b/packages/envex/src/react/EnvexProvider/index.tsx
@@ -10,22 +10,23 @@ import { fetchEnv } from './utils'
 
 const EnvexProvider = (props: EnvexProviderPropsInterface) => {
   const { initialEnv, prefix, endpoint, schema, children } = props
+  const [rawEnv, setRawEnv] = useState<Env | null>(null)
   const [env, setEnv] = useState<Env>(
-    initialEnv ? filterPublicEnv(initialEnv, prefix) : {}
+    initialEnv && !schema ? filterPublicEnv(initialEnv, prefix) : {}
   )
   const [error, setError] = useState<Error | null>(null)
 
   if (error) throw error
 
+  // Fetches raw env from endpoint or window.ENV — no schema dependency so
+  // the effect doesn't re-run when schema identity changes.
   useEffect(() => {
     let isCancelled = false
 
     if (endpoint) {
       void fetchEnv(endpoint)
-        .then(async (data: Env) => {
-          if (isCancelled) return
-          const result = schema ? await validateEnv(schema, data) : data
-          if (!isCancelled) setEnv(result as Env)
+        .then((data: Env) => {
+          if (!isCancelled) setRawEnv(data)
         })
         .catch((err: unknown) => {
           if (!isCancelled) {
@@ -50,10 +51,10 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
             'window.ENV is required. Use EnvScript (Next.js), set window.ENV manually via a <script> tag, or use the endpoint prop.'
           )
         }
-        return schema ? validateEnv(schema, window.ENV) : window.ENV
+        return window.ENV
       })
-      .then(result => {
-        if (!isCancelled) setEnv(result as Env)
+      .then(data => {
+        if (!isCancelled) setRawEnv(data)
       })
       .catch((err: unknown) => {
         if (!isCancelled) {
@@ -69,7 +70,33 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
     return () => {
       isCancelled = true
     }
-  }, [endpoint, schema])
+  }, [endpoint])
+
+  // Validates raw env against schema and publishes the result. Runs whenever
+  // the raw data or schema changes, decoupled from the fetch effect above.
+  useEffect(() => {
+    if (rawEnv === null) return
+    let isCancelled = false
+
+    void Promise.resolve(schema ? validateEnv(schema, rawEnv) : rawEnv)
+      .then(result => {
+        if (!isCancelled) setEnv(result as Env)
+      })
+      .catch((err: unknown) => {
+        if (!isCancelled) {
+          if (err instanceof Error) {
+            setError(err)
+          } else {
+            console.error('[envex] Failed to validate env:', err)
+            setError(new Error(String(err)))
+          }
+        }
+      })
+
+    return () => {
+      isCancelled = true
+    }
+  }, [rawEnv, schema])
 
   return <EnvexContext.Provider value={env}>{children}</EnvexContext.Provider>
 }

--- a/packages/envex/src/react/EnvexProvider/index.tsx
+++ b/packages/envex/src/react/EnvexProvider/index.tsx
@@ -3,16 +3,20 @@
 import { useEffect, useRef, useState } from 'react'
 import { EnvexWindowEnvIsMissingError } from '../../errors.ts'
 import type { Env } from '../../types.ts'
-import { filterPublicEnv } from '../../utils'
+import { filterPublicEnv, validateEnv } from '../../utils'
 import { EnvexContext } from './contexts'
 import type { EnvexProviderPropsInterface } from './types.ts'
 import { fetchEnv } from './utils'
 
 const EnvexProvider = (props: EnvexProviderPropsInterface) => {
-  const { initialEnv, prefix, endpoint, fetchStrategy, children } = props
+  const { initialEnv, prefix, endpoint, fetchStrategy, schema, children } =
+    props
   const [env, setEnv] = useState<Env>(
     initialEnv ? filterPublicEnv(initialEnv, prefix) : {}
   )
+  const [error, setError] = useState<Error | null>(null)
+
+  if (error) throw error
 
   // Keep the latest strategy in a ref so the fetch effect can read it without
   // depending on it — an inline `fetchStrategy` prop would otherwise change
@@ -38,14 +42,18 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
       let isCancelled = false
 
       void request
-        .then((data: Env) => {
-          if (!isCancelled) {
-            setEnv(data)
-          }
+        .then(async (data: Env) => {
+          if (isCancelled) return
+          const result = schema ? await validateEnv(schema, data) : data
+          if (!isCancelled) setEnv(result as Env)
         })
-        .catch((error: unknown) => {
+        .catch((err: unknown) => {
           if (!isCancelled) {
-            console.error('[envex] Failed to fetch env from endpoint:', error)
+            if (err instanceof Error) {
+              setError(err)
+            } else {
+              console.error('[envex] Failed to fetch env from endpoint:', err)
+            }
           }
         })
 
@@ -60,8 +68,23 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
       )
     }
 
-    setEnv(window.ENV)
-  }, [endpoint])
+    let isCancelled = false
+    const windowEnv = window.ENV
+
+    void Promise.resolve(schema ? validateEnv(schema, windowEnv) : windowEnv)
+      .then(result => {
+        if (!isCancelled) setEnv(result as Env)
+      })
+      .catch((err: unknown) => {
+        if (!isCancelled && err instanceof Error) {
+          setError(err)
+        }
+      })
+
+    return () => {
+      isCancelled = true
+    }
+  }, [endpoint, schema])
 
   return <EnvexContext.Provider value={env}>{children}</EnvexContext.Provider>
 }

--- a/packages/envex/src/react/EnvexProvider/index.tsx
+++ b/packages/envex/src/react/EnvexProvider/index.tsx
@@ -80,7 +80,10 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
 
     void Promise.resolve(schema ? validateEnv(schema, rawEnv) : rawEnv)
       .then(result => {
-        if (!isCancelled) setEnv(result as Env)
+        if (!isCancelled)
+          setEnv(
+            schema ? (result as Env) : filterPublicEnv(result as Env, prefix)
+          )
       })
       .catch((err: unknown) => {
         if (!isCancelled) {
@@ -96,7 +99,7 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
     return () => {
       isCancelled = true
     }
-  }, [rawEnv, schema])
+  }, [rawEnv, schema, prefix])
 
   return <EnvexContext.Provider value={env}>{children}</EnvexContext.Provider>
 }

--- a/packages/envex/src/react/EnvexProvider/index.tsx
+++ b/packages/envex/src/react/EnvexProvider/index.tsx
@@ -53,6 +53,7 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
               setError(err)
             } else {
               console.error('[envex] Failed to fetch env from endpoint:', err)
+              setError(new Error(String(err)))
             }
           }
         })
@@ -76,8 +77,13 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
         if (!isCancelled) setEnv(result as Env)
       })
       .catch((err: unknown) => {
-        if (!isCancelled && err instanceof Error) {
-          setError(err)
+        if (!isCancelled) {
+          if (err instanceof Error) {
+            setError(err)
+          } else {
+            console.error('[envex] Failed to load env from window.ENV:', err)
+            setError(new Error(String(err)))
+          }
         }
       })
 

--- a/packages/envex/src/react/EnvexProvider/index.tsx
+++ b/packages/envex/src/react/EnvexProvider/index.tsx
@@ -43,15 +43,15 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
       }
     }
 
-    if (!window.ENV || typeof window.ENV !== 'object') {
-      throw new EnvexWindowEnvIsMissingError(
-        'window.ENV is required. Use EnvScript (Next.js), set window.ENV manually via a <script> tag, or use the endpoint prop.'
-      )
-    }
-
-    const windowEnv = window.ENV
-
-    void Promise.resolve(schema ? validateEnv(schema, windowEnv) : windowEnv)
+    void Promise.resolve()
+      .then(() => {
+        if (!window.ENV || typeof window.ENV !== 'object') {
+          throw new EnvexWindowEnvIsMissingError(
+            'window.ENV is required. Use EnvScript (Next.js), set window.ENV manually via a <script> tag, or use the endpoint prop.'
+          )
+        }
+        return schema ? validateEnv(schema, window.ENV) : window.ENV
+      })
       .then(result => {
         if (!isCancelled) setEnv(result as Env)
       })

--- a/packages/envex/src/react/EnvexProvider/index.tsx
+++ b/packages/envex/src/react/EnvexProvider/index.tsx
@@ -11,8 +11,9 @@ import { fetchEnv } from './utils'
 const EnvexProvider = (props: EnvexProviderPropsInterface) => {
   const { initialEnv, prefix, endpoint, fetchStrategy, schema, children } =
     props
+  const [rawEnv, setRawEnv] = useState<Env | null>(null)
   const [env, setEnv] = useState<Env>(
-    initialEnv ? filterPublicEnv(initialEnv, prefix) : {}
+    initialEnv && !schema ? filterPublicEnv(initialEnv, prefix) : {}
   )
   const [error, setError] = useState<Error | null>(null)
 
@@ -27,6 +28,8 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
     fetchStrategyRef.current = fetchStrategy
   }, [fetchStrategy])
 
+  // Fetches raw env from endpoint, an injected strategy, or window.ENV — no
+  // schema dependency so the effect doesn't re-run when schema identity changes.
   useEffect(() => {
     const strategy = fetchStrategyRef.current
     let request: Promise<Env> | null = null
@@ -38,14 +41,12 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
       request = fetchEnv(endpoint)
     }
 
-    if (request) {
-      let isCancelled = false
+    let isCancelled = false
 
+    if (request) {
       void request
-        .then(async (data: Env) => {
-          if (isCancelled) return
-          const result = schema ? await validateEnv(schema, data) : data
-          if (!isCancelled) setEnv(result as Env)
+        .then((data: Env) => {
+          if (!isCancelled) setRawEnv(data)
         })
         .catch((err: unknown) => {
           if (!isCancelled) {
@@ -63,8 +64,6 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
       }
     }
 
-    let isCancelled = false
-
     void Promise.resolve()
       .then(() => {
         if (!window.ENV || typeof window.ENV !== 'object') {
@@ -72,10 +71,10 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
             'window.ENV is required. Use EnvScript (Next.js), set window.ENV manually via a <script> tag, or use the endpoint prop.'
           )
         }
-        return schema ? validateEnv(schema, window.ENV) : window.ENV
+        return window.ENV
       })
-      .then(result => {
-        if (!isCancelled) setEnv(result as Env)
+      .then(data => {
+        if (!isCancelled) setRawEnv(data)
       })
       .catch((err: unknown) => {
         if (!isCancelled) {
@@ -91,7 +90,33 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
     return () => {
       isCancelled = true
     }
-  }, [endpoint, schema])
+  }, [endpoint])
+
+  // Validates raw env against schema and publishes the result. Runs whenever
+  // the raw data or schema changes, decoupled from the fetch effect above.
+  useEffect(() => {
+    if (rawEnv === null) return
+    let isCancelled = false
+
+    void Promise.resolve(schema ? validateEnv(schema, rawEnv) : rawEnv)
+      .then(result => {
+        if (!isCancelled) setEnv(result as Env)
+      })
+      .catch((err: unknown) => {
+        if (!isCancelled) {
+          if (err instanceof Error) {
+            setError(err)
+          } else {
+            console.error('[envex] Failed to validate env:', err)
+            setError(new Error(String(err)))
+          }
+        }
+      })
+
+    return () => {
+      isCancelled = true
+    }
+  }, [rawEnv, schema])
 
   return <EnvexContext.Provider value={env}>{children}</EnvexContext.Provider>
 }

--- a/packages/envex/src/react/EnvexProvider/index.tsx
+++ b/packages/envex/src/react/EnvexProvider/index.tsx
@@ -3,30 +3,37 @@
 import { useEffect, useState } from 'react'
 import { EnvexWindowEnvIsMissingError } from '../../errors.ts'
 import type { Env } from '../../types.ts'
-import { filterPublicEnv } from '../../utils'
+import { filterPublicEnv, validateEnv } from '../../utils'
 import { EnvexContext } from './contexts'
 import type { EnvexProviderPropsInterface } from './types.ts'
 import { fetchEnv } from './utils'
 
 const EnvexProvider = (props: EnvexProviderPropsInterface) => {
-  const { initialEnv, prefix, endpoint, children } = props
+  const { initialEnv, prefix, endpoint, schema, children } = props
   const [env, setEnv] = useState<Env>(
     initialEnv ? filterPublicEnv(initialEnv, prefix) : {}
   )
+  const [error, setError] = useState<Error | null>(null)
+
+  if (error) throw error
 
   useEffect(() => {
-    if (endpoint) {
-      let isCancelled = false
+    let isCancelled = false
 
+    if (endpoint) {
       void fetchEnv(endpoint)
-        .then((data: Env) => {
-          if (!isCancelled) {
-            setEnv(data)
-          }
+        .then(async (data: Env) => {
+          if (isCancelled) return
+          const result = schema ? await validateEnv(schema, data) : data
+          if (!isCancelled) setEnv(result as Env)
         })
-        .catch((error: unknown) => {
+        .catch((err: unknown) => {
           if (!isCancelled) {
-            console.error('[envex] Failed to fetch env from endpoint:', error)
+            if (err instanceof Error) {
+              setError(err)
+            } else {
+              console.error('[envex] Failed to fetch env from endpoint:', err)
+            }
           }
         })
 
@@ -41,9 +48,22 @@ const EnvexProvider = (props: EnvexProviderPropsInterface) => {
       )
     }
 
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setEnv(window.ENV)
-  }, [endpoint])
+    const windowEnv = window.ENV
+
+    void Promise.resolve(schema ? validateEnv(schema, windowEnv) : windowEnv)
+      .then(result => {
+        if (!isCancelled) setEnv(result as Env)
+      })
+      .catch((err: unknown) => {
+        if (!isCancelled && err instanceof Error) {
+          setError(err)
+        }
+      })
+
+    return () => {
+      isCancelled = true
+    }
+  }, [endpoint, schema])
 
   return <EnvexContext.Provider value={env}>{children}</EnvexContext.Provider>
 }

--- a/packages/envex/src/react/EnvexProvider/types.ts
+++ b/packages/envex/src/react/EnvexProvider/types.ts
@@ -1,3 +1,4 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 import type { ReactNode } from 'react'
 import type { Env, EnvFetchStrategy } from '../../types.ts'
 
@@ -6,5 +7,6 @@ export interface EnvexProviderPropsInterface {
   prefix?: string | null
   endpoint?: string
   fetchStrategy?: EnvFetchStrategy
+  schema?: StandardSchemaV1
   children: ReactNode
 }

--- a/packages/envex/src/react/EnvexProvider/types.ts
+++ b/packages/envex/src/react/EnvexProvider/types.ts
@@ -1,3 +1,4 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 import type { ReactNode } from 'react'
 import type { Env } from '../../types.ts'
 
@@ -5,5 +6,6 @@ export interface EnvexProviderPropsInterface {
   initialEnv?: Env
   prefix?: string | null
   endpoint?: string
+  schema?: StandardSchemaV1
   children: ReactNode
 }

--- a/packages/envex/src/react/EnvexProvider/utils/fetchEnvCache/index.ts
+++ b/packages/envex/src/react/EnvexProvider/utils/fetchEnvCache/index.ts
@@ -1,9 +1,4 @@
-import type { Env } from '../../../../types.ts'
-
-interface FetchEnvCache {
-  promise: Promise<Env> | null
-  endpoint: string | null
-}
+import type { FetchEnvCache } from './types.ts'
 
 const fetchEnvCache: FetchEnvCache = {
   promise: null,

--- a/packages/envex/src/react/EnvexProvider/utils/fetchEnvCache/types.ts
+++ b/packages/envex/src/react/EnvexProvider/utils/fetchEnvCache/types.ts
@@ -1,0 +1,6 @@
+import type { Env } from '../../../../types'
+
+export interface FetchEnvCache {
+  promise: Promise<Env> | null
+  endpoint: string | null
+}

--- a/packages/envex/src/types.ts
+++ b/packages/envex/src/types.ts
@@ -1,3 +1,5 @@
+export type { StandardSchemaV1 } from '@standard-schema/spec'
+
 export type Env = Record<string, string | undefined>
 
 export type EnvFetchStrategy = (endpoint: string) => Promise<Env>

--- a/packages/envex/src/types.ts
+++ b/packages/envex/src/types.ts
@@ -1,3 +1,5 @@
+export type { StandardSchemaV1 } from '@standard-schema/spec'
+
 export type Env = Record<string, string | undefined>
 
 declare global {

--- a/packages/envex/src/utils/index.ts
+++ b/packages/envex/src/utils/index.ts
@@ -3,3 +3,4 @@ export {
   assertNoCredentialLeak,
   scanForCredentials,
 } from './scanForCredentials'
+export { validateEnv } from './validateEnv'

--- a/packages/envex/src/utils/index.ts
+++ b/packages/envex/src/utils/index.ts
@@ -1,1 +1,2 @@
 export { default as filterPublicEnv } from './filterPublicEnv'
+export { validateEnv } from './validateEnv'

--- a/packages/envex/src/utils/validateEnv/index.ts
+++ b/packages/envex/src/utils/validateEnv/index.ts
@@ -1,0 +1,19 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
+import { EnvexValidationError } from '../../errors.ts'
+
+export const validateEnv = async <TSchema extends StandardSchemaV1>(
+  schema: TSchema,
+  env: unknown
+): Promise<StandardSchemaV1.InferOutput<TSchema>> => {
+  let result = schema['~standard'].validate(env)
+
+  if (result instanceof Promise) {
+    result = await result
+  }
+
+  if (result.issues) {
+    throw new EnvexValidationError(result.issues)
+  }
+
+  return result.value
+}

--- a/packages/envex/tests/react/EnvexProvider/index.spec.tsx
+++ b/packages/envex/tests/react/EnvexProvider/index.spec.tsx
@@ -4,6 +4,7 @@ import { render } from 'vitest-browser-react'
 import {
   EnvexProvider,
   EnvexScriptIsMissingError,
+  EnvexValidationError,
   EnvexWindowEnvIsMissingError,
 } from '../../../src'
 import resetFetchEnvCache from '../../../src/react/EnvexProvider/utils/resetFetchEnvCache'
@@ -15,6 +16,17 @@ const makePassSchema = (
     version: 1,
     vendor: 'test',
     validate: () => ({ value: output }),
+  },
+})
+
+const makeFailSchema = (): StandardSchemaV1<
+  unknown,
+  Record<string, string>
+> => ({
+  '~standard': {
+    version: 1,
+    vendor: 'test',
+    validate: () => ({ issues: [{ message: 'invalid' }] }),
   },
 })
 
@@ -120,6 +132,38 @@ test('Schema validates fetched env from endpoint.', async () => {
   )
 
   await expect.element(getByText('Children')).toBeInTheDocument()
+})
+
+test('Schema validation failure on window.ENV surfaces EnvexValidationError.', async () => {
+  window.ENV = { NEXT_PUBLIC_API_URL: 'https://api.example.com' }
+  const schema = makeFailSchema()
+
+  try {
+    await render(<EnvexProvider schema={schema}>Children</EnvexProvider>)
+  } catch (error) {
+    expect(error).toBeInstanceOf(EnvexValidationError)
+  }
+
+  delete window.ENV
+})
+
+test('Schema validation failure on endpoint surfaces EnvexValidationError.', async () => {
+  const mockEnv = { API_URL: 'https://api.example.com' }
+  const schema = makeFailSchema()
+
+  vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+    json: () => Promise.resolve(mockEnv),
+  } as Response)
+
+  try {
+    await render(
+      <EnvexProvider endpoint='/api/env' schema={schema}>
+        Children
+      </EnvexProvider>
+    )
+  } catch (error) {
+    expect(error).toBeInstanceOf(EnvexValidationError)
+  }
 })
 
 test('Multiple providers with same endpoint fire only one fetch.', async () => {

--- a/packages/envex/tests/react/EnvexProvider/index.spec.tsx
+++ b/packages/envex/tests/react/EnvexProvider/index.spec.tsx
@@ -1,3 +1,4 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 import { afterEach, expect, test, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 import {
@@ -6,6 +7,16 @@ import {
   EnvexWindowEnvIsMissingError,
 } from '../../../src'
 import resetFetchEnvCache from '../../../src/react/EnvexProvider/utils/resetFetchEnvCache'
+
+const makePassSchema = (
+  output: Record<string, string>
+): StandardSchemaV1<unknown, Record<string, string>> => ({
+  '~standard': {
+    version: 1,
+    vendor: 'test',
+    validate: () => ({ value: output }),
+  },
+})
 
 afterEach(() => {
   resetFetchEnvCache()
@@ -77,6 +88,38 @@ test('Try to render "EnvProvider" with endpoint ignores window.ENV.', async () =
   await expect.element(getByText('Children')).toBeInTheDocument()
 
   delete window.ENV
+})
+
+test('Schema validates window.ENV and provider renders children.', async () => {
+  window.ENV = { NEXT_PUBLIC_API_URL: 'https://api.example.com' }
+  const schema = makePassSchema({
+    NEXT_PUBLIC_API_URL: 'https://api.example.com',
+  })
+
+  const { getByText } = await render(
+    <EnvexProvider schema={schema}>Children</EnvexProvider>
+  )
+
+  await expect.element(getByText('Children')).toBeInTheDocument()
+
+  delete window.ENV
+})
+
+test('Schema validates fetched env from endpoint.', async () => {
+  const mockEnv = { API_URL: 'https://api.example.com' }
+  const schema = makePassSchema(mockEnv)
+
+  vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+    json: () => Promise.resolve(mockEnv),
+  } as Response)
+
+  const { getByText } = await render(
+    <EnvexProvider endpoint='/api/env' schema={schema}>
+      Children
+    </EnvexProvider>
+  )
+
+  await expect.element(getByText('Children')).toBeInTheDocument()
 })
 
 test('Multiple providers with same endpoint fire only one fetch.', async () => {

--- a/packages/envex/tests/react/EnvexProvider/index.spec.tsx
+++ b/packages/envex/tests/react/EnvexProvider/index.spec.tsx
@@ -4,6 +4,7 @@ import { render } from 'vitest-browser-react'
 import {
   EnvexProvider,
   EnvexScriptIsMissingError,
+  EnvexValidationError,
   EnvexWindowEnvIsMissingError,
 } from '../../../src'
 import resetFetchEnvCache from '../../../src/react/EnvexProvider/utils/resetFetchEnvCache'
@@ -15,6 +16,17 @@ const makePassSchema = (
     version: 1,
     vendor: 'test',
     validate: () => ({ value: output }),
+  },
+})
+
+const makeFailSchema = (): StandardSchemaV1<
+  unknown,
+  Record<string, string>
+> => ({
+  '~standard': {
+    version: 1,
+    vendor: 'test',
+    validate: () => ({ issues: [{ message: 'invalid' }] }),
   },
 })
 
@@ -122,6 +134,38 @@ test('Schema validates fetched env from endpoint.', async () => {
   )
 
   await expect.element(getByText('Children')).toBeInTheDocument()
+})
+
+test('Schema validation failure on window.ENV surfaces EnvexValidationError.', async () => {
+  window.ENV = { NEXT_PUBLIC_API_URL: 'https://api.example.com' }
+  const schema = makeFailSchema()
+
+  try {
+    await render(<EnvexProvider schema={schema}>Children</EnvexProvider>)
+  } catch (error) {
+    expect(error).toBeInstanceOf(EnvexValidationError)
+  }
+
+  delete window.ENV
+})
+
+test('Schema validation failure on endpoint surfaces EnvexValidationError.', async () => {
+  const mockEnv = { API_URL: 'https://api.example.com' }
+  const schema = makeFailSchema()
+
+  vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+    json: () => Promise.resolve(mockEnv),
+  } as Response)
+
+  try {
+    await render(
+      <EnvexProvider endpoint='/api/env' schema={schema}>
+        Children
+      </EnvexProvider>
+    )
+  } catch (error) {
+    expect(error).toBeInstanceOf(EnvexValidationError)
+  }
 })
 
 test('Multiple providers with same endpoint fire only one fetch.', async () => {

--- a/packages/envex/tests/react/EnvexProvider/index.spec.tsx
+++ b/packages/envex/tests/react/EnvexProvider/index.spec.tsx
@@ -137,6 +137,7 @@ test('Schema validates fetched env from endpoint.', async () => {
 })
 
 test('Schema validation failure on window.ENV surfaces EnvexValidationError.', async () => {
+  expect.assertions(1)
   window.ENV = { NEXT_PUBLIC_API_URL: 'https://api.example.com' }
   const schema = makeFailSchema()
 
@@ -150,6 +151,7 @@ test('Schema validation failure on window.ENV surfaces EnvexValidationError.', a
 })
 
 test('Schema validation failure on endpoint surfaces EnvexValidationError.', async () => {
+  expect.assertions(1)
   const mockEnv = { API_URL: 'https://api.example.com' }
   const schema = makeFailSchema()
 

--- a/packages/envex/tests/react/EnvexProvider/index.spec.tsx
+++ b/packages/envex/tests/react/EnvexProvider/index.spec.tsx
@@ -135,6 +135,7 @@ test('Schema validates fetched env from endpoint.', async () => {
 })
 
 test('Schema validation failure on window.ENV surfaces EnvexValidationError.', async () => {
+  expect.assertions(1)
   window.ENV = { NEXT_PUBLIC_API_URL: 'https://api.example.com' }
   const schema = makeFailSchema()
 
@@ -148,6 +149,7 @@ test('Schema validation failure on window.ENV surfaces EnvexValidationError.', a
 })
 
 test('Schema validation failure on endpoint surfaces EnvexValidationError.', async () => {
+  expect.assertions(1)
   const mockEnv = { API_URL: 'https://api.example.com' }
   const schema = makeFailSchema()
 

--- a/packages/envex/tests/react/EnvexProvider/index.spec.tsx
+++ b/packages/envex/tests/react/EnvexProvider/index.spec.tsx
@@ -124,6 +124,7 @@ test('Schema validates fetched env from endpoint.', async () => {
   const schema = makePassSchema(mockEnv)
 
   vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+    ok: true,
     json: () => Promise.resolve(mockEnv),
   } as Response)
 
@@ -156,6 +157,7 @@ test('Schema validation failure on endpoint surfaces EnvexValidationError.', asy
   const schema = makeFailSchema()
 
   vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+    ok: true,
     json: () => Promise.resolve(mockEnv),
   } as Response)
 

--- a/packages/envex/tests/react/EnvexProvider/index.spec.tsx
+++ b/packages/envex/tests/react/EnvexProvider/index.spec.tsx
@@ -1,3 +1,4 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
 import { afterEach, expect, test, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 import {
@@ -6,6 +7,16 @@ import {
   EnvexWindowEnvIsMissingError,
 } from '../../../src'
 import resetFetchEnvCache from '../../../src/react/EnvexProvider/utils/resetFetchEnvCache'
+
+const makePassSchema = (
+  output: Record<string, string>
+): StandardSchemaV1<unknown, Record<string, string>> => ({
+  '~standard': {
+    version: 1,
+    vendor: 'test',
+    validate: () => ({ value: output }),
+  },
+})
 
 afterEach(() => {
   resetFetchEnvCache()
@@ -79,6 +90,38 @@ test('Try to render "EnvProvider" with endpoint ignores window.ENV.', async () =
   await expect.element(getByText('Children')).toBeInTheDocument()
 
   delete window.ENV
+})
+
+test('Schema validates window.ENV and provider renders children.', async () => {
+  window.ENV = { NEXT_PUBLIC_API_URL: 'https://api.example.com' }
+  const schema = makePassSchema({
+    NEXT_PUBLIC_API_URL: 'https://api.example.com',
+  })
+
+  const { getByText } = await render(
+    <EnvexProvider schema={schema}>Children</EnvexProvider>
+  )
+
+  await expect.element(getByText('Children')).toBeInTheDocument()
+
+  delete window.ENV
+})
+
+test('Schema validates fetched env from endpoint.', async () => {
+  const mockEnv = { API_URL: 'https://api.example.com' }
+  const schema = makePassSchema(mockEnv)
+
+  vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+    json: () => Promise.resolve(mockEnv),
+  } as Response)
+
+  const { getByText } = await render(
+    <EnvexProvider endpoint='/api/env' schema={schema}>
+      Children
+    </EnvexProvider>
+  )
+
+  await expect.element(getByText('Children')).toBeInTheDocument()
 })
 
 test('Multiple providers with same endpoint fire only one fetch.', async () => {

--- a/packages/envex/tests/react/EnvexProvider/index.spec.tsx
+++ b/packages/envex/tests/react/EnvexProvider/index.spec.tsx
@@ -6,8 +6,15 @@ import {
   EnvexScriptIsMissingError,
   EnvexValidationError,
   EnvexWindowEnvIsMissingError,
+  useEnv,
 } from '../../../src'
 import resetFetchEnvCache from '../../../src/react/EnvexProvider/utils/resetFetchEnvCache'
+
+const ShowEnv = ({ envKey }: { envKey: string }) => {
+  const env = useEnv()
+
+  return <span>value:{env[envKey]}</span>
+}
 
 const makePassSchema = (
   output: Record<string, string>
@@ -104,22 +111,26 @@ test('Try to render "EnvProvider" with endpoint ignores window.ENV.', async () =
   delete window.ENV
 })
 
-test('Schema validates window.ENV and provider renders children.', async () => {
+test('Schema validates window.ENV and provider exposes validated value.', async () => {
   window.ENV = { NEXT_PUBLIC_API_URL: 'https://api.example.com' }
   const schema = makePassSchema({
     NEXT_PUBLIC_API_URL: 'https://api.example.com',
   })
 
   const { getByText } = await render(
-    <EnvexProvider schema={schema}>Children</EnvexProvider>
+    <EnvexProvider schema={schema}>
+      <ShowEnv envKey='NEXT_PUBLIC_API_URL' />
+    </EnvexProvider>
   )
 
-  await expect.element(getByText('Children')).toBeInTheDocument()
+  await expect
+    .element(getByText('value:https://api.example.com'))
+    .toBeInTheDocument()
 
   delete window.ENV
 })
 
-test('Schema validates fetched env from endpoint.', async () => {
+test('Schema validates fetched env from endpoint and exposes validated value.', async () => {
   const mockEnv = { API_URL: 'https://api.example.com' }
   const schema = makePassSchema(mockEnv)
 
@@ -130,11 +141,13 @@ test('Schema validates fetched env from endpoint.', async () => {
 
   const { getByText } = await render(
     <EnvexProvider endpoint='/api/env' schema={schema}>
-      Children
+      <ShowEnv envKey='API_URL' />
     </EnvexProvider>
   )
 
-  await expect.element(getByText('Children')).toBeInTheDocument()
+  await expect
+    .element(getByText('value:https://api.example.com'))
+    .toBeInTheDocument()
 })
 
 test('Schema validation failure on window.ENV surfaces EnvexValidationError.', async () => {

--- a/packages/envex/tests/utils/validateEnv/index.spec.ts
+++ b/packages/envex/tests/utils/validateEnv/index.spec.ts
@@ -1,0 +1,100 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
+import { expect, test } from 'vitest'
+import { EnvexValidationError } from '../../../src/errors'
+import { validateEnv } from '../../../src/utils/validateEnv'
+
+const makePassSchema = <TOut>(
+  transform: (v: unknown) => TOut
+): StandardSchemaV1<unknown, TOut> => ({
+  '~standard': {
+    version: 1,
+    vendor: 'test',
+    validate: v => ({ value: transform(v) }),
+  },
+})
+
+const makeFailSchema = (message: string): StandardSchemaV1<unknown, never> => ({
+  '~standard': {
+    version: 1,
+    vendor: 'test',
+    validate: () => ({ issues: [{ message }] }),
+  },
+})
+
+const makeAsyncPassSchema = <TOut>(
+  transform: (v: unknown) => TOut
+): StandardSchemaV1<unknown, TOut> => ({
+  '~standard': {
+    version: 1,
+    vendor: 'test',
+    validate: v => Promise.resolve({ value: transform(v) }),
+  },
+})
+
+const makeAsyncFailSchema = (
+  message: string
+): StandardSchemaV1<unknown, never> => ({
+  '~standard': {
+    version: 1,
+    vendor: 'test',
+    validate: () => Promise.resolve({ issues: [{ message }] }),
+  },
+})
+
+test('returns parsed value when sync schema passes', async () => {
+  const input = { NEXT_PUBLIC_API_URL: 'https://api.example.com' }
+  const schema = makePassSchema(v => v as typeof input)
+
+  const result = await validateEnv(schema, input)
+
+  expect(result).toEqual(input)
+})
+
+test('throws EnvexValidationError when sync schema fails', async () => {
+  const schema = makeFailSchema('Required')
+
+  await expect(validateEnv(schema, {})).rejects.toBeInstanceOf(
+    EnvexValidationError
+  )
+})
+
+test('includes issue messages in error', async () => {
+  const schema = makeFailSchema('API_URL is required')
+
+  try {
+    await validateEnv(schema, {})
+  } catch (error) {
+    expect(error).toBeInstanceOf(EnvexValidationError)
+    if (error instanceof EnvexValidationError) {
+      expect(error.issues).toHaveLength(1)
+      expect(error.issues[0].message).toBe('API_URL is required')
+      expect(error.message).toContain('API_URL is required')
+    }
+  }
+})
+
+test('returns parsed value when async schema passes', async () => {
+  const input = { NEXT_PUBLIC_X: 'hello' }
+  const schema = makeAsyncPassSchema(v => v as typeof input)
+
+  const result = await validateEnv(schema, input)
+
+  expect(result).toEqual(input)
+})
+
+test('throws EnvexValidationError when async schema fails', async () => {
+  const schema = makeAsyncFailSchema('Invalid')
+
+  await expect(validateEnv(schema, {})).rejects.toBeInstanceOf(
+    EnvexValidationError
+  )
+})
+
+test('schema can transform value', async () => {
+  const input = { COUNT: '42' }
+  const schema = makePassSchema(() => ({ COUNT: 42 }))
+
+  const result = await validateEnv(schema, input)
+
+  expect(result).toEqual({ COUNT: 42 })
+})

--- a/packages/envex/tests/utils/validateEnv/index.spec.ts
+++ b/packages/envex/tests/utils/validateEnv/index.spec.ts
@@ -59,6 +59,7 @@ test('throws EnvexValidationError when sync schema fails', async () => {
 })
 
 test('includes issue messages in error', async () => {
+  expect.assertions(4)
   const schema = makeFailSchema('API_URL is required')
 
   try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
     devDependencies:
       '@playwright/test':
         specifier: ^1.61.1
@@ -4412,6 +4415,9 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -8733,5 +8739,7 @@ snapshots:
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
+
+  zod@3.25.76: {}
 
   zod@4.4.3: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,7 +115,7 @@ importers:
         version: link:../../packages/envex
       next:
         specifier: ^16.2.4
-        version: 16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -156,6 +156,9 @@ importers:
 
   packages/envex:
     dependencies:
+      '@standard-schema/spec':
+        specifier: ^1.1.0
+        version: 1.1.0
       next:
         specifier: ^15 || ^16
         version: 16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -7378,6 +7381,31 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@next/env': 16.2.4
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.25
+      caniuse-lite: 1.0.30001791
+      postcss: 8.4.31
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      styled-jsx: 5.1.6(react@19.2.5)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.4
+      '@next/swc-darwin-x64': 16.2.4
+      '@next/swc-linux-arm64-gnu': 16.2.4
+      '@next/swc-linux-arm64-musl': 16.2.4
+      '@next/swc-linux-x64-gnu': 16.2.4
+      '@next/swc-linux-x64-musl': 16.2.4
+      '@next/swc-win32-arm64-msvc': 16.2.4
+      '@next/swc-win32-x64-msvc': 16.2.4
+      '@playwright/test': 1.59.1
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
   node-emoji@2.2.0:
     dependencies:
       '@sindresorhus/is': 4.6.0
@@ -8123,6 +8151,11 @@ snapshots:
       react: 19.2.5
     optionalDependencies:
       '@babel/core': 7.29.0
+
+  styled-jsx@5.1.6(react@19.2.5):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.5
 
   super-regex@1.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,13 +115,16 @@ importers:
         version: link:../../packages/envex
       next:
         specifier: ^16.2.4
-        version: 16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react:
         specifier: ^19.2.5
         version: 19.2.5
       react-dom:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
     devDependencies:
       '@playwright/test':
         specifier: ^1.59.1
@@ -4296,6 +4299,9 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.4.2:
     resolution: {integrity: sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==}
 
@@ -6387,7 +6393,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -6424,7 +6430,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -6438,7 +6444,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7381,31 +7387,6 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.2.4(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
-    dependencies:
-      '@next/env': 16.2.4
-      '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.25
-      caniuse-lite: 1.0.30001791
-      postcss: 8.4.31
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-      styled-jsx: 5.1.6(react@19.2.5)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.4
-      '@next/swc-darwin-x64': 16.2.4
-      '@next/swc-linux-arm64-gnu': 16.2.4
-      '@next/swc-linux-arm64-musl': 16.2.4
-      '@next/swc-linux-x64-gnu': 16.2.4
-      '@next/swc-linux-x64-musl': 16.2.4
-      '@next/swc-win32-arm64-msvc': 16.2.4
-      '@next/swc-win32-x64-msvc': 16.2.4
-      '@playwright/test': 1.59.1
-      sharp: 0.34.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
   node-emoji@2.2.0:
     dependencies:
       '@sindresorhus/is': 4.6.0
@@ -8152,11 +8133,6 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
 
-  styled-jsx@5.1.6(react@19.2.5):
-    dependencies:
-      client-only: 0.0.1
-      react: 19.2.5
-
   super-regex@1.1.0:
     dependencies:
       function-timeout: 1.0.2
@@ -8594,5 +8570,7 @@ snapshots:
   zod-validation-error@4.0.2(zod@4.4.2):
     dependencies:
       zod: 4.4.2
+
+  zod@3.25.76: {}
 
   zod@4.4.2: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
 
   packages/envex:
     dependencies:
+      '@standard-schema/spec':
+        specifier: ^1.1.0
+        version: 1.1.0
       next:
         specifier: ^15 || ^16
         version: 16.2.10(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -6544,7 +6547,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.10
       eslint: 9.39.5(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.6.1)))(eslint@9.39.5(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.6.1))
@@ -6571,7 +6574,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.6.1)))(eslint@9.39.5(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -6586,13 +6589,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.6.1)):
+  eslint-module-utils@2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.6.1)))(eslint@9.39.5(jiti@2.6.1)))(eslint@9.39.5(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.5(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.6.1)))(eslint@9.39.5(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -6607,7 +6610,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.6.1))
+      eslint-module-utils: 2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.5(jiti@2.6.1)))(eslint@9.39.5(jiti@2.6.1)))(eslint@9.39.5(jiti@2.6.1))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary

- Add optional schema validation via any [Standard Schema](https://standardschema.dev)-compatible library (Zod, Valibot, ArkType, etc.) — no hard dependency on any specific library
- Add `EnvexValidationError` with `issues: StandardSchemaV1.Issue[]` for detailed error reporting
- Accept `schema?` prop/option on all touch points: `getEnv`, `getPublicEnv`, `createEnvRouteHandler`, `EnvScript`, `InlineEnvScript`, `EnvexProvider`
- Add generic overload `useEnv<TSchema>()` returning `StandardSchemaV1.InferOutput<TSchema>` for end-to-end type safety
- Propagate validation errors via React error state so they reach error boundaries correctly
- Update README with full validation documentation including Zod examples

Backward compatible — without `schema`, behavior is identical to before.

## Test plan

- [x] `validateEnv` unit tests: sync schema pass/fail, async schema pass/fail, issue aggregation, value transformation
- [x] `EnvexProvider` schema tests: validates `window.ENV`, validates fetched endpoint response
- [x] All existing 26 tests pass
- [x] Build succeeds (`pnpm build`)
- [x] Lint clean (`pnpm lint`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Standard Schema-based validation to the provider, schema-aware `useEnv` typing, Next.js route handling, environment getters, and injected env scripts.
  * Introduced `EnvexValidationError` with validation `issues`, plus schema-inferred return types.

* **Documentation**
  * Expanded README with a new **Validation** section and detailed `schema` API coverage.
  * Updated public-env credential scanning to use `getPublicEnv({ scan })` and documented `prefix` behavior.

* **Tests**
  * Added unit tests for `validateEnv` and React tests covering success, failure, async/sync behavior, and transforms.

* **Chores**
  * Updated ESLint config and added the Standard Schema dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->